### PR TITLE
Updates Dependency for npm-run-all

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -50,7 +50,7 @@
     "@types/validate.js": "0.11.0",
     "babel-plugin-transform-inline-environment-variables": "0.4.3",
     "jest-preset-ignite": "0.6.1",
-    "npm-run-all": "4.1.3",
+    "npm-run-all": "4.1.5",
     "patch-package": "5.1.1",
     "postinstall-prepare": "1.0.1",
     "prettier": "1.12.1",


### PR DESCRIPTION
Hello!
This PR updates npm-run-all to 4.1.5 to address a security issue detailed here: https://github.com/dominictarr/event-stream/issues/116

Also twitter for reference: https://twitter.com/bcrypt/status/1067137019753582592

Relevant:  https://github.com/mozilla/firefox-test-tube/pull/286 - documents that "4.1.5" shouldn't be used...? 

Have a great Cyber Monday (or what's left of it) :wave: 

