### PR TITLE
Bump npm-run-all version for security

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -50,7 +50,7 @@
     "@types/validate.js": "0.11.0",
     "babel-plugin-transform-inline-environment-variables": "0.4.3",
     "jest-preset-ignite": "0.6.1",
-    "npm-run-all": "4.1.3",
+    "npm-run-all": "4.1.5",
     "patch-package": "5.1.1",
     "postinstall-prepare": "1.0.1",
     "prettier": "1.12.1",


### PR DESCRIPTION
npm-run-all 4.1.3 depends indirectly on flatmap-stream, which has been yanked
from npm because it contained malicious code:

https://www.npmjs.com/advisories/737
https://github.com/mysticatea/npm-run-all/issues/149