### PR TITLE
fix: Lock react-devtools-core to 3.4.3 to avoid issue with 3.5.0

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -53,6 +53,7 @@
     "patch-package": "5.1.1",
     "postinstall-prepare": "1.0.1",
     "prettier": "1.12.1",
+    "react-devtools-core": "3.4.3",
     "react-dom": "16.5.0",
     "react-powerplug": "0.1.5",
     "rimraf": "2.6.2",


### PR DESCRIPTION
Ref: https://github.com/facebook/react-native/issues/22863