### PR TITLE
navigationStore caching problem

### DIFF
--- a/boilerplate/src/app/setup-root-store.ts
+++ b/boilerplate/src/app/setup-root-store.ts
@@ -23,6 +23,11 @@ export async function setupRootStore() {
     // load data from storage
     data = (await storage.load(ROOT_STATE_STORAGE_KEY)) || {}
     rootStore = RootStoreModel.create(data, env)
+    
+    // if it's not dev.
+    if (!__DEV__)
+      rootStore.navigationStore.reset()
+    
   } catch(e) {
     // if there's any problems loading, then let's at least fallback to an empty state
     // instead of crashing.


### PR DESCRIPTION
If the navigation is modified, if the APP obtains the navigationStore from the sotre and finds that the route does not exist, it will report an error. I think this mode is very good for the start mode. It can be refreshed to stay in the current interface, but the released version, if this mode is also enabled. Even if you cover a new application, there will be this problem.