### PR TITLE
Fix api-problem's translation of 404 errors

### DIFF
--- a/boilerplate/src/services/api/api-problem.test.ts
+++ b/boilerplate/src/services/api/api-problem.test.ts
@@ -1,0 +1,72 @@
+import { getGeneralApiProblem } from "./api-problem"
+import { ApiErrorResponse } from "apisauce"
+
+test("handles connection errors", () => {
+  expect(getGeneralApiProblem({ problem: "CONNECTION_ERROR" } as ApiErrorResponse<null>)).toEqual({
+    kind: "cannot-connect",
+    temporary: true,
+  })
+})
+
+test("handles network errors", () => {
+  expect(getGeneralApiProblem({ problem: "NETWORK_ERROR" } as ApiErrorResponse<null>)).toEqual({
+    kind: "cannot-connect",
+    temporary: true,
+  })
+})
+
+test("handles timeouts", () => {
+  expect(getGeneralApiProblem({ problem: "TIMEOUT_ERROR" } as ApiErrorResponse<null>)).toEqual({
+    kind: "timeout",
+    temporary: true,
+  })
+})
+
+test("handles server errors", () => {
+  expect(getGeneralApiProblem({ problem: "SERVER_ERROR" } as ApiErrorResponse<null>)).toEqual({
+    kind: "server",
+  })
+})
+
+test("handles unknown errors", () => {
+  expect(getGeneralApiProblem({ problem: "UNKNOWN_ERROR" } as ApiErrorResponse<null>)).toEqual({
+    kind: "unknown",
+    temporary: true,
+  })
+})
+
+test("handles unauthorized errors", () => {
+  expect(
+    getGeneralApiProblem({ problem: "CLIENT_ERROR", status: 401 } as ApiErrorResponse<null>),
+  ).toEqual({
+    kind: "unauthorized",
+  })
+})
+
+test("handles forbidden errors", () => {
+  expect(
+    getGeneralApiProblem({ problem: "CLIENT_ERROR", status: 403 } as ApiErrorResponse<null>),
+  ).toEqual({
+    kind: "forbidden",
+  })
+})
+
+test("handles not-found errors", () => {
+  expect(
+    getGeneralApiProblem({ problem: "CLIENT_ERROR", status: 404 } as ApiErrorResponse<null>),
+  ).toEqual({
+    kind: "not-found",
+  })
+})
+
+test("handles other client errors", () => {
+  expect(
+    getGeneralApiProblem({ problem: "CLIENT_ERROR", status: 418 } as ApiErrorResponse<null>),
+  ).toEqual({
+    kind: "rejected",
+  })
+})
+
+test("handles cancellation errors", () => {
+  expect(getGeneralApiProblem({ problem: "CANCEL_ERROR" } as ApiErrorResponse<null>)).toBeNull()
+})

--- a/boilerplate/src/services/api/api-problem.ts
+++ b/boilerplate/src/services/api/api-problem.ts
@@ -61,6 +61,8 @@ export function getGeneralApiProblem(response: ApiResponse<any>): GeneralApiProb
           return { kind: "unauthorized" }
         case 403:
           return { kind: "forbidden" }
+        case 404:
+          return { kind: "not-found" }
         default:
           return { kind: "rejected" }
       }

--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -8,19 +8,27 @@ const BOILERPLATE = `${__dirname}/../`
 // calling the ignite cli takes a while
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 800000
 
-describe('with a linter', () => {
+describe('a generated app', () => {
   // creates a new temp directory
-  const linterTemp = tempy.directory()
+  const appTemp = tempy.directory()
   beforeAll(async () => {
     // make sure we are in the temp directory
-    process.chdir(linterTemp)
+    process.chdir(appTemp)
     await execa(IGNITE, ['new', APP, '--skip-git', '--boilerplate', BOILERPLATE])
     process.chdir(APP)
   })
 
   afterAll(() => {
     // clean up generated test app
-    jetpack.remove(linterTemp)
+    jetpack.remove(appTemp)
+  })
+
+  test('can yarn install and pass tests', async () => {
+    return execa.shell("yarn install 2>&1")
+    .then(() => execa.shell("npm test 2>&1"))
+    .catch(error => {
+      expect(error.stdout).toEqual('') // will fail & show the yarn or test errors
+    })
   })
 
   test('does have a linting script', async () => {


### PR DESCRIPTION
My project’s API started 404ing today, causing me to notice that the boilerplate `getGeneralApiProblem()` doesn’t correctly translate 404 errors.

I added a test for all of its translations, made the test pass, and copied the test to this project… and noticed that we don’t have a test that ensures that new apps’ tests pass, so I added that too. (Surprisingly, it doesn’t seem to add to the test time, because of jest’s parallelism? — tests still take about 320s on my machine. 🎉 )
