### PR TITLE
Add optional Detox end-to-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,11 @@ defaults: &defaults
     - image: circleci/node:10.11
   working_directory: ~/repo
 
+mac: &mac
+  macos:
+    xcode: "10.1.0"
+  working_directory: ~/repo
+
 version: 2
 jobs:
   setup:
@@ -50,6 +55,52 @@ jobs:
           name: Run tests
           command: yarn ci:test # this command will be added to/found in your package.json scripts
 
+  detox:
+    <<: *mac
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore node modules
+          keys:
+            - v1-dependencies-mac-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-mac-
+      - run:
+          name: Install dependencies
+          command: |
+            yarn install
+      - save_cache:
+          name: Save node modules
+          paths:
+            - node_modules
+          key: v1-dependencies-mac-{{ checksum "package.json" }}
+      - run:
+          name: Install React Native CLI and Ignite CLI
+          command: |
+            sudo npm i -g ignite-cli react-native-cli detox-cli
+      - run:
+          name: Install applesimutils
+          command: brew tap wix/brew && brew install applesimutils
+      - run:
+          name: Install fbsimctl
+          command: brew tap facebook/fb
+      - run:
+          name: Create temp directory
+          command: mkdir tempApp
+      - run:
+          name: Ignite app
+          command: cd tempApp && ignite new DetoxTests --detox --skip-git -b ../
+      - run:
+          name: Build Detox in ignited app
+          command: cd tempApp/DetoxTests && detox build
+      - run:
+          name: Run detox tests in ignited app
+          command: cd tempApp/DetoxTests && detox test -c ios.sim.debug -l verbose --cleanup
+      - run:
+          name: Remove temp directory
+          command: rm -rf tempApp
+
+
   publish:
     <<: *defaults
     steps:
@@ -74,6 +125,7 @@ workflows:
       - tests:
           requires:
             - setup
+      - detox
       - publish:
           requires:
             - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,10 @@ jobs:
           command: cd tempApp && ignite new DetoxTests --detox --skip-git -b ../
       - run:
           name: Build Detox in ignited app
-          command: cd tempApp/DetoxTests && detox build
+          command: cd tempApp/DetoxTests && detox build -c ios.sim.release
       - run:
           name: Run detox tests in ignited app
-          command: cd tempApp/DetoxTests && detox test -c ios.sim.debug -l verbose --cleanup
+          command: cd tempApp/DetoxTests && detox test -c ios.sim.release -l verbose --cleanup
       - run:
           name: Remove temp directory
           command: rm -rf tempApp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
 mac: &mac
   macos:
     xcode: "10.1.0"
-  working_directory: /Users/distiller/project
+  working_directory: ~/repo
 
 version: 2
 jobs:
@@ -60,8 +60,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Set permissions
-          command: chmod -R 777 /Users/distiller/project
+          name: Change Permissions
+          command: sudo chown -R $(whoami) /Users/distiller
       - restore_cache:
           name: Restore node modules
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,9 +59,6 @@ jobs:
     <<: *mac
     steps:
       - checkout
-      - run:
-          name: Change Permissions
-          command: sudo chown -R $(whoami) /Users/distiller
       - restore_cache:
           name: Restore node modules
           keys:
@@ -81,6 +78,9 @@ jobs:
           name: Install React Native CLI and Ignite CLI
           command: |
             sudo npm i -g ignite-cli react-native-cli detox-cli
+      - run:
+          name: Change Permissions
+          command: sudo chown -R $(whoami) /Users/distiller/.config/
       - run:
           name: Install applesimutils
           command: brew tap wix/brew && brew install applesimutils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
 mac: &mac
   macos:
     xcode: "10.1.0"
-  working_directory: ~/repo
+  working_directory: /Users/distiller/project
 
 version: 2
 jobs:
@@ -59,6 +59,9 @@ jobs:
     <<: *mac
     steps:
       - checkout
+      - run:
+          name: Set permissions
+          command: chmod -R 777 /Users/distiller/project
       - restore_cache:
           name: Restore node modules
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,10 @@ jobs:
           command: cd tempApp && ignite new DetoxTests --detox --skip-git -b ../
       - run:
           name: Build Detox in ignited app
-          command: cd tempApp/DetoxTests && detox build -c ios.sim.release
+          command: cd tempApp/DetoxTests && yarn ci:build:e2e
       - run:
           name: Run detox tests in ignited app
-          command: cd tempApp/DetoxTests && detox test -c ios.sim.release -l verbose --cleanup
+          command: cd tempApp/DetoxTests && yarn ci:test:e2e
       - run:
           name: Remove temp directory
           command: rm -rf tempApp

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -60,7 +60,8 @@ async function install(context) {
   ]
   filesToRemove.map(filesystem.remove)
 
-  const includeDetox = await prompt.confirm('Would you like to include Detox end-to-end tests?')
+  const askAboutDetox = !parameters.options.detox
+  const includeDetox = askAboutDetox ? await prompt.confirm('Would you like to include Detox end-to-end tests?') : parameters.options.detox === 'true'
 
   if (includeDetox) {
     print.info(`You'll love Detox for testing your app! There are some additional requirements to install, so make sure to check out ${cyan('e2e/README.md')}!`)

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -161,6 +161,9 @@ async function install(context) {
     if (!includeDetox) {
       delete newPackage.detox
       delete newPackage.scripts["test:e2e"]
+      delete newPackage.scripts["build:e2e"]
+      delete newPackage.scripts["ci:build:e2e"]
+      delete newPackage.scripts["ci:test:e2e"]
       delete newPackage.devDependencies.detox
     }
 

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -171,15 +171,6 @@ async function install(context) {
       )
     )(currentPackage)
 
-    if (!includeDetox) {
-      delete newPackage.detox
-      delete newPackage.scripts["test:e2e"]
-      delete newPackage.scripts["build:e2e"]
-      delete newPackage.scripts["ci:build:e2e"]
-      delete newPackage.scripts["ci:test:e2e"]
-      delete newPackage.devDependencies.detox
-    }
-
     // write this out
     filesystem.write('package.json', newPackage, { jsonIndent: 2 })
   }

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -35,6 +35,8 @@ async function install(context) {
   } = context
   const { colors } = print
   const { red, yellow, bold, gray, blue, cyan } = colors
+  const isWindows = process.platform === 'win32'
+  const isMac = process.platform === 'darwin'
 
   const perfStart = (new Date()).getTime()
 
@@ -60,11 +62,22 @@ async function install(context) {
   ]
   filesToRemove.map(filesystem.remove)
 
-  const askAboutDetox = !parameters.options.detox
-  const includeDetox = askAboutDetox ? await prompt.confirm('Would you like to include Detox end-to-end tests?') : parameters.options.detox === true
+  let includeDetox = false
+  if (isMac) {
+    const askAboutDetox = parameters.options.detox === undefined
+    includeDetox = askAboutDetox ? await prompt.confirm('Would you like to include Detox end-to-end tests?') : parameters.options.detox === true
 
-  if (includeDetox) {
-    print.info(`You'll love Detox for testing your app! There are some additional requirements to install, so make sure to check out ${cyan('e2e/README.md')}!`)
+    if (includeDetox) {
+      print.info(`You'll love Detox for testing your app! There are some additional requirements to install, so make sure to check out ${cyan('e2e/README.md')}!`)
+    }
+  } else {
+    if (parameters.options.detox === 'true') {
+      if (isWindows) {
+        print.info("Skipping Detox because it is only supported on macOS, but you're running Windows")
+      } else {
+        print.info("Skipping Detox because it is only supported on macOS")
+      }
+    }
   }
 
   // copy our App, Tests & storybook directories

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -61,7 +61,7 @@ async function install(context) {
   filesToRemove.map(filesystem.remove)
 
   const askAboutDetox = !parameters.options.detox
-  const includeDetox = askAboutDetox ? await prompt.confirm('Would you like to include Detox end-to-end tests?') : parameters.options.detox === 'true'
+  const includeDetox = askAboutDetox ? await prompt.confirm('Would you like to include Detox end-to-end tests?') : parameters.options.detox === true
 
   if (includeDetox) {
     print.info(`You'll love Detox for testing your app! There are some additional requirements to install, so make sure to check out ${cyan('e2e/README.md')}!`)

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -71,7 +71,7 @@ async function install(context) {
       print.info(`You'll love Detox for testing your app! There are some additional requirements to install, so make sure to check out ${cyan('e2e/README.md')}!`)
     }
   } else {
-    if (parameters.options.detox === 'true') {
+    if (parameters.options.detox === true) {
       if (isWindows) {
         print.info("Skipping Detox because it is only supported on macOS, but you're running Windows")
       } else {

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -56,7 +56,6 @@ async function install(context) {
   const filesToRemove = [
     '__tests__',
     'App.js',
-    '.babelrc',
     '.flowconfig',
     '.buckconfig',
   ]
@@ -113,6 +112,7 @@ async function install(context) {
     { template: '.gitignore', target: '.gitignore' },
     { template: '.prettierignore', target: '.prettierignore' },
     { template: '.solidarity', target: '.solidarity' },
+    { template: '.babelrc', target: '.babelrc' },
     { template: 'tsconfig.json', target: 'tsconfig.json' },
     { template: 'tslint.json', target: 'tslint.json' },
     { template: 'app/app.tsx.ejs', target: 'app/app.tsx' },

--- a/boilerplate/.babelrc
+++ b/boilerplate/.babelrc
@@ -1,0 +1,24 @@
+{
+  "presets": ["module:metro-react-native-babel-preset"],
+  "env": {
+    "production": {
+    }
+  },
+  "plugins": [
+    [
+      "transform-inline-environment-variables",
+      {
+        "include": ["NODE_ENV", "API"]
+      }
+    ],
+    [
+      "@babel/plugin-proposal-decorators",
+      {
+        "legacy": true
+      }
+    ],
+    [
+      "@babel/plugin-proposal-optional-catch-binding"
+    ]
+  ]
+}

--- a/boilerplate/app/screens/first-example-screen/first-example-screen.tsx.ejs
+++ b/boilerplate/app/screens/first-example-screen/first-example-screen.tsx.ejs
@@ -85,7 +85,11 @@ export class FirstExampleScreen extends React.Component<FirstExampleScreenProps,
 
   render() {
     return (
+<% if (props.includeDetox) { -%>
+      <View testID="FirstExampleScreen" style={FULL}>
+<% } else { -%>
       <View style={FULL}>
+<% } -%>
         <StatusBar barStyle="light-content" />
         <Wallpaper />
         <SafeAreaView style={FULL}>
@@ -113,6 +117,9 @@ export class FirstExampleScreen extends React.Component<FirstExampleScreenProps,
         <SafeAreaView style={FOOTER}>
           <View style={FOOTER_CONTENT}>
             <Button
+<% if (props.includeDetox) { -%>
+              testID="next-screen-button"
+<% } -%>
               style={CONTINUE}
               textStyle={CONTINUE_TEXT}
               tx="firstExampleScreen.continue"

--- a/boilerplate/app/screens/second-example-screen/second-example-screen.tsx.ejs
+++ b/boilerplate/app/screens/second-example-screen/second-example-screen.tsx.ejs
@@ -116,7 +116,11 @@ export class SecondExampleScreen extends React.Component<SecondExampleScreenProp
 
   render() {
     return (
+    <% if (props.includeDetox) { -%>
+      <View testID="SecondExampleScreen" style={FULL}>
+    <% } else { -%>
       <View style={FULL}>
+    <% } -%>
         <Wallpaper />
         <SafeAreaView style={FULL}>
           <Screen style={CONTAINER} backgroundColor={color.transparent} preset="scrollStack">

--- a/boilerplate/e2e/README.md
+++ b/boilerplate/e2e/README.md
@@ -43,13 +43,21 @@ Note that in order to pick up elements by ID, we've added the `testID` prop to t
 
 ## Running tests
 
-1. Run the app
+1. Start the packager
+
+```
+yarn start
+```
+
+2. Run the app
+
+In a separate terminal window from the packager:
 
 ```
 yarn build:e2e
 ```
 
-2. Run the tests
+3. Run the tests
 
 ```
 yarn test:e2e

--- a/boilerplate/e2e/README.md
+++ b/boilerplate/e2e/README.md
@@ -46,7 +46,7 @@ Note that in order to pick up elements by ID, we've added the `testID` prop to t
 1. Run the app
 
 ```
-react-native run-ios
+yarn build:e2e
 ```
 
 2. Run the tests

--- a/boilerplate/e2e/README.md
+++ b/boilerplate/e2e/README.md
@@ -1,0 +1,58 @@
+# Detox End-To-End Testing
+
+## Setup
+
+To get your Detox tests up and running, you'll need to install some global dependencies:
+
+1. Install the latest version of [Homebrew](https://brew.sh/)
+2. Make sure you're running node 8.6.0 or higher. If you aren't, you can run:
+
+```bash
+nvm install 8.6.0
+```
+
+or
+
+```bash
+brew update && brew install node 8.6.0
+```
+
+3. Install `applesimutils, which will allow Detox to communicate with the iOS simulator:
+
+```bash
+brew tap wix/brew && brew install applesimutils
+```
+
+4. Install `fbsimctl`
+
+```bash
+brew tap facebook/fb
+```
+
+5. Install the Detox CLI
+
+```bash
+  yarn global add detox-cli
+```
+
+## Adding tests
+
+We've gotten you started with `./e2e/firstTest.spec.js`, which tests that the two main example screens render properly.
+
+Note that in order to pick up elements by ID, we've added the `testID` prop to the component.
+
+## Running tests
+
+1. Run the app
+
+```
+react-native run-ios
+```
+
+2. Run the tests
+
+```
+yarn test:e2e
+```
+
+For more information, make sure to check out the official [Detox Docs](https://github.com/wix/Detox/blob/master/docs/README.md)

--- a/boilerplate/e2e/README.md
+++ b/boilerplate/e2e/README.md
@@ -23,13 +23,7 @@ brew update && brew install node 8.6.0
 brew tap wix/brew && brew install applesimutils
 ```
 
-4. Install `fbsimctl`
-
-```bash
-brew tap facebook/fb
-```
-
-5. Install the Detox CLI
+4. Install the Detox CLI
 
 ```bash
   yarn global add detox-cli

--- a/boilerplate/e2e/README.md
+++ b/boilerplate/e2e/README.md
@@ -5,17 +5,18 @@
 To get your Detox tests up and running, you'll need to install some global dependencies:
 
 1. Install the latest version of [Homebrew](https://brew.sh/)
-2. Make sure you're running node 8.6.0 or higher. If you aren't, you can run:
+2. Make sure you have Node installed (at least 8.6.0). If you don't:
 
+If you use NVM:
 ```bash
-nvm install 8.6.0
+nvm install node
 ```
 
-or
-
+Or if you'd prefer to install directly from Homebrew
 ```bash
-brew update && brew install node 8.6.0
+brew update && brew install node
 ```
+
 
 3. Install `applesimutils, which will allow Detox to communicate with the iOS simulator:
 

--- a/boilerplate/e2e/config.json
+++ b/boilerplate/e2e/config.json
@@ -1,0 +1,4 @@
+{
+    "setupTestFrameworkScriptFile": "./init.js",
+    "testEnvironment": "node"
+}

--- a/boilerplate/e2e/config.json
+++ b/boilerplate/e2e/config.json
@@ -1,4 +1,4 @@
 {
-    "setupTestFrameworkScriptFile": "./init.js",
+    "setupFilesAfterEnv": ["./init.js"],
     "testEnvironment": "node"
 }

--- a/boilerplate/e2e/firstTest.spec.js
+++ b/boilerplate/e2e/firstTest.spec.js
@@ -1,3 +1,6 @@
+// For more info on how to write Detox tests, see the official docs:
+// https://github.com/wix/Detox/blob/master/docs/README.md
+
 describe('Example', () => {
   beforeEach(async () => {
     await device.reloadReactNative();

--- a/boilerplate/e2e/firstTest.spec.js
+++ b/boilerplate/e2e/firstTest.spec.js
@@ -1,0 +1,14 @@
+describe('Example', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('should have welcome screen', async () => {
+    await expect(element(by.id("FirstExampleScreen"))).toBeVisible();
+  });
+
+  it('should go to next screen after tap', async () => {
+    await element(by.id('next-screen-button')).tap();
+    await expect(element(by.id('SecondExampleScreen'))).toBeVisible();
+  });
+});

--- a/boilerplate/e2e/init.js
+++ b/boilerplate/e2e/init.js
@@ -1,0 +1,19 @@
+const detox = require('detox');
+const config = require('../package.json').detox;
+const adapter = require('detox/runners/jest/adapter');
+
+jest.setTimeout(120000);
+jasmine.getEnv().addReporter(adapter);
+
+beforeAll(async () => {
+  await detox.init(config);
+});
+
+beforeEach(async () => {
+  await adapter.beforeEach();
+});
+
+afterAll(async () => {
+  await adapter.afterAll();
+  await detox.cleanup();
+});

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -77,30 +77,6 @@
     "preset": "jest-preset-ignite",
     "testPathIgnorePatterns": ["/node_modules/", "/e2e"]
   },
-  "babel": {
-    "presets": ["module:metro-react-native-babel-preset"],
-    "env": {
-      "production": {
-      }
-    },
-    "plugins": [
-      [
-        "@babel/plugin-proposal-decorators",
-        {
-          "legacy": true
-        }
-      ],
-      [
-        "transform-inline-environment-variables",
-        {
-          "include": ["NODE_ENV", "API"]
-        }
-      ],
-      [
-        "@babel/plugin-proposal-optional-catch-binding"
-      ]
-    ]
-  },
   "prettier": {
     "printWidth": 100,
     "semi": false,

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -109,7 +109,7 @@
     "configurations": {
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/<%= props.name %>.app",
-        "build": "xcodebuild -project ios/<%= props.name %>.xcodeproj -scheme <%= props.name %> -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+        "build": "xcodebuild -project ios/<%= props.name %>.xcodeproj -scheme <%= props.name %> -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
         "type": "ios.simulator",
         "name": "iPhone 8"
       }

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -70,7 +70,8 @@
     "typescript": "3.0.3"
   },
   "jest": {
-    "preset": "jest-preset-ignite"
+    "preset": "jest-preset-ignite",
+    "testPathIgnorePatterns": ["/node_modules/", "/e2e"]
   },
   "babel": {
     "presets": ["module:metro-react-native-babel-preset"],
@@ -80,15 +81,15 @@
     },
     "plugins": [
       [
-        "transform-inline-environment-variables",
-        {
-          "include": ["NODE_ENV", "API"]
-        }
-      ],
-      [
         "@babel/plugin-proposal-decorators",
         {
           "legacy": true
+        }
+      ],
+      [
+        "transform-inline-environment-variables",
+        {
+          "include": ["NODE_ENV", "API"]
         }
       ],
       [

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "test:e2e": "detox test -c ios.sim.debug",
     "compile": "tsc --noEmit -p . --pretty",
     "format": "npm-run-all format:*",
     "format:js": "prettier --write {.,**}/*.js",
@@ -36,11 +37,13 @@
     "validate.js": "0.12.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0-0",
     "@babel/runtime": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
     "@storybook/addon-storyshots": "^4.0.6",
     "@storybook/react-native": "3.4.3",
+    "babel-core": "7.0.0-bridge.0",
     "@types/jest": "23.3.2",
     "@types/ramda": "0.25.28",
     "@types/react": "16.7.7",
@@ -48,6 +51,7 @@
     "@types/react-navigation": "2.13.5",
     "@types/react-test-renderer": "16.0.3",
     "babel-plugin-transform-inline-environment-variables": "0.4.3",
+    "detox": "^10.0.2",
     "jest-preset-ignite": "0.6.1",
     "npm-run-all": "4.1.5",
     "patch-package": "5.1.1",
@@ -99,5 +103,16 @@
     "assets": [
       "./app/theme/fonts/"
     ]
+  },
+  "detox": {
+    "test-runner": "jest",
+    "configurations": {
+      "ios.sim.debug": {
+        "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/<%= props.name %>.app",
+        "build": "xcodebuild -project ios/<%= props.name %>.xcodeproj -scheme <%= props.name %> -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+        "type": "ios.simulator",
+        "name": "iPhone 8"
+      }
+    }
   }
 }

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -4,6 +4,9 @@
   "private": true,
   "scripts": {
     "test:e2e": "detox test -c ios.sim.debug",
+    "build:e2e": "detox build -c ios.sim.debug",
+    "ci:test:e2e": "detox test -c ios.sim.release -l verbose --cleanup",
+    "ci:build:e2e": "detox build -c ios.sim.release",
     "compile": "tsc --noEmit -p . --pretty",
     "format": "npm-run-all format:*",
     "format:js": "prettier --write {.,**}/*.js",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -3,10 +3,12 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+<% if (props.includeDetox) { -%>
     "test:e2e": "detox test -c ios.sim.debug",
     "build:e2e": "detox build -c ios.sim.debug",
     "ci:test:e2e": "detox test -c ios.sim.release -l verbose --cleanup",
     "ci:build:e2e": "detox build -c ios.sim.release",
+<% } -%>
     "compile": "tsc --noEmit -p . --pretty",
     "format": "npm-run-all format:*",
     "format:js": "prettier --write {.,**}/*.js",
@@ -54,7 +56,9 @@
     "@types/react-navigation": "2.13.5",
     "@types/react-test-renderer": "16.0.3",
     "babel-plugin-transform-inline-environment-variables": "0.4.3",
+<% if (props.includeDetox) { -%>
     "detox": "^10.0.2",
+<% } -%>
     "jest-preset-ignite": "0.6.1",
     "npm-run-all": "4.1.5",
     "patch-package": "5.1.1",
@@ -103,11 +107,7 @@
     "singleQuote": false,
     "trailingComma": "all"
   },
-  "rnpm": {
-    "assets": [
-      "./app/theme/fonts/"
-    ]
-  },
+  <% if (props.includeDetox) { -%>
   "detox": {
     "test-runner": "jest",
     "configurations": {
@@ -124,5 +124,11 @@
         "name": "iPhone 8"
       }
     }
+  },
+<% } -%>
+  "rnpm": {
+    "assets": [
+      "./app/theme/fonts/"
+    ]
   }
 }

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -112,6 +112,12 @@
         "build": "xcodebuild -project ios/<%= props.name %>.xcodeproj -scheme <%= props.name %> -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
         "type": "ios.simulator",
         "name": "iPhone 8"
+      },
+      "ios.sim.release": {
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/<%= props.name %>.app",
+        "build": "xcodebuild -project ios/<%= props.name %>.xcodeproj -scheme <%= props.name %> -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
+        "type": "ios.simulator",
+        "name": "iPhone 8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
   },
   "dependencies": {
     "ramda": "^0.25.0"
+  },
+  "jest": {
+    "testPathIgnorePatterns": ["/node_modules", "/boilerplate"]
   }
 }

--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -14,7 +14,7 @@ describe('a generated app', () => {
   beforeAll(async () => {
     // make sure we are in the temp directory
     process.chdir(appTemp)
-    await execa(IGNITE, ['new', APP, '--skip-git', '--boilerplate', BOILERPLATE])
+    await execa(IGNITE, ['new', APP, '--no-detox','--skip-git', '--boilerplate', BOILERPLATE])
     process.chdir(APP)
   })
 
@@ -25,7 +25,7 @@ describe('a generated app', () => {
 
   test('can yarn install and pass tests', async () => {
     return execa.shell("yarn install 2>&1")
-    .then(() => execa.shell("npm test 2>&1"))
+    .then(() => execa.shell("yarn test 2>&1"))
     .catch(error => {
       expect(error.stdout).toEqual('') // will fail & show the yarn or test errors
     })
@@ -42,7 +42,7 @@ describe('generators', () => {
   beforeAll(async () => {
     // make sure we are in the temp directory
     process.chdir(generatorsTemp)
-    await execa(IGNITE, ['new', APP, '--skip-git', '--boilerplate', BOILERPLATE])
+    await execa(IGNITE, ['new', APP, '--no-detox', '--skip-git', '--boilerplate',  BOILERPLATE])
     process.chdir(APP)
   })
 


### PR DESCRIPTION
This adds the option for the user to include Detox end-to-end tests with their Ignited app.

They will have to install some additional dependencies in order to run the tests, but I've included a specific README to go over what they need to do. They are pointed towards this README during the Ignite process after they say yes to Detox. 

I've also added a job to the CI workflow that ignites an app with Detox and ensures that the Detox tests pass. 

If you'd like to skip the question when Igniting (so you can run it and forget it without waiting for the prompt) you can use `--detox` or `--no-detox`.

<img width="1058" alt="screen shot 2019-01-24 at 4 04 51 pm" src="https://user-images.githubusercontent.com/6894653/51716612-50397400-1ff2-11e9-977f-5210252a9475.png">

![capture](https://user-images.githubusercontent.com/6894653/51858344-5d53ad00-22e9-11e9-8d69-276d0a89831a.PNG)


<img width="691" alt="screen shot 2019-01-24 at 2 47 47 pm" src="https://user-images.githubusercontent.com/6894653/51716611-50397400-1ff2-11e9-97ba-ccd4f3f7efbf.png">