### PR TITLE
Fix (& test for) type errors on new projects

### DIFF
--- a/boilerplate/test/mock-textinput.ts
+++ b/boilerplate/test/mock-textinput.ts
@@ -1,5 +1,5 @@
 jest.mock("TextInput", () => {
-  const RealComponent = require.requireActual("TextInput")
+  const RealComponent = (require as any).requireActual("TextInput")
   const React = require("React")
 
   class TextInput extends React.Component {

--- a/boilerplate/tsconfig.json
+++ b/boilerplate/tsconfig.json
@@ -10,6 +10,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "target": "es2015"
   },

--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -23,11 +23,12 @@ describe('a generated app', () => {
     jetpack.remove(appTemp)
   })
 
-  test('can yarn install and pass tests', async () => {
-    return execa.shell("yarn install 2>&1")
-    .then(() => execa.shell("npm test 2>&1"))
+  test('can lint, compile, and pass tests', async () => {
+    return execa.shell("yarn run lint 2>&1")
+    .then(() => execa.shell("yarn run compile 2>&1"))
+    .then(() => execa.shell("yarn test 2>&1"))
     .catch(error => {
-      expect(error.stdout).toEqual('') // will fail & show the yarn or test errors
+      expect(error.stdout).toEqual('') // will fail & show the errors
     })
   })
 


### PR DESCRIPTION
On a new project, `npm run compile` fails with a big pile of type errors, all but one of which are from `@types/react-native/globals.d.ts` (see below for the actual type errors).

This PR:

- adds `skipLibCheck: true` to `tsconfig.json`, which'll tell typescript to not complain about the problems from `*.d.ts` files;

- fixes the one remaining type error, which is in our boilerplate code, by casting a `require` to `any` (necessary because `@types/react-native/globals.d.ts` declares `require` as a simple function with no extra `requireActual` property);

- changes the generators-integration test to run `yarn run lint` and `yarn run compile` to make sure new generated projects start life with no type errors. (It also removes the `yarn install` that test used to run, which speeds up the test by a minute or so -- `ignite new` runs `yarn install` before it finishes.)

<details><summary>Expand to see all the original errors</summary>
<p>
```

    node_modules/@types/react-native/globals.d.ts:36:15 - error TS2300: Duplicate identifier 'FormData'.

    36 declare class FormData {
                     ~~~~~~~~

      node_modules/typescript/lib/lib.dom.d.ts:5367:11
        5367 interface FormData {
                       ~~~~~~~~
        'FormData' was also declared here.

    node_modules/@types/react-native/globals.d.ts:66:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'body' must be of type 'BodyInit', but here has type 'string | ArrayBuffer | DataView | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | Blob | FormData'.

    66   body?: BodyInit_;
         ~~~~

    node_modules/@types/react-native/globals.d.ts:92:14 - error TS2300: Duplicate identifier 'RequestInfo'.

    92 declare type RequestInfo = Request | string;
                    ~~~~~~~~~~~

      node_modules/typescript/lib/lib.dom.d.ts:17155:6
        17155 type RequestInfo = Request | string;
                   ~~~~~~~~~~~
        'RequestInfo' was also declared here.

    node_modules/@types/react-native/globals.d.ts:111:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'Response' must be of type '{ new (body?: BodyInit, init?: ResponseInit): Response; prototype: Response; error(): Response; redirect(url: string, status?: number): Response; }', but here has type '{ new (body?: string | ArrayBuffer | DataView | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | Blob | FormData, init?: ResponseInit): Response; prototype: Response; error: () => Response; redirect: (url: string, status?: number) => Res...'.

    111 declare var Response: {
                    ~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:175:3 - error TS2717: Subsequent property declarations must have the same type.  Property '\"abort\"' must be of type 'ProgressEvent', but here has type 'Event'.

    175   \"abort\": Event;
          ~~~~~~~

    node_modules/@types/react-native/globals.d.ts:176:3 - error TS2717: Subsequent property declarations must have the same type.  Property '\"error\"' must be of type 'ProgressEvent', but here has type 'Event'.

    176   \"error\": Event;
          ~~~~~~~

    node_modules/@types/react-native/globals.d.ts:177:3 - error TS2717: Subsequent property declarations must have the same type.  Property '\"load\"' must be of type 'ProgressEvent', but here has type 'Event'.

    177   \"load\": Event;
          ~~~~~~

    node_modules/@types/react-native/globals.d.ts:178:3 - error TS2717: Subsequent property declarations must have the same type.  Property '\"loadend\"' must be of type 'ProgressEvent', but here has type 'Event'.

    178   \"loadend\": Event;
          ~~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:179:3 - error TS2717: Subsequent property declarations must have the same type.  Property '\"loadstart\"' must be of type 'ProgressEvent', but here has type 'Event'.

    179   \"loadstart\": Event;
          ~~~~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:180:3 - error TS2717: Subsequent property declarations must have the same type.  Property '\"progress\"' must be of type 'ProgressEvent', but here has type 'Event'.

    180   \"progress\": Event;
          ~~~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:181:3 - error TS2717: Subsequent property declarations must have the same type.  Property '\"timeout\"' must be of type 'ProgressEvent', but here has type 'Event'.

    181   \"timeout\": Event;
          ~~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:185:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'onabort' must be of type '(this: XMLHttpRequest, ev: ProgressEvent) => any', but here has type '(this: XMLHttpRequest, ev: Event) => any'.

    185   onabort: ((this: XMLHttpRequest, ev: Event) => any) | null;
          ~~~~~~~

    node_modules/@types/react-native/globals.d.ts:186:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'onerror' must be of type '(this: XMLHttpRequest, ev: ProgressEvent) => any', but here has type '(this: XMLHttpRequest, ev: Event) => any'.

    186   onerror: ((this: XMLHttpRequest, ev: Event) => any) | null;
          ~~~~~~~

    node_modules/@types/react-native/globals.d.ts:187:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'onload' must be of type '(this: XMLHttpRequest, ev: ProgressEvent) => any', but here has type '(this: XMLHttpRequest, ev: Event) => any'.

    187   onload: ((this: XMLHttpRequest, ev: Event) => any) | null;
          ~~~~~~

    node_modules/@types/react-native/globals.d.ts:188:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'onloadend' must be of type '(this: XMLHttpRequest, ev: ProgressEvent) => any', but here has type '(this: XMLHttpRequest, ev: Event) => any'.

    188   onloadend: ((this: XMLHttpRequest, ev: Event) => any) | null;
          ~~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:189:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'onloadstart' must be of type '(this: XMLHttpRequest, ev: ProgressEvent) => any', but here has type '(this: XMLHttpRequest, ev: Event) => any'.

    189   onloadstart: ((this: XMLHttpRequest, ev: Event) => any) | null;
          ~~~~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:190:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'onprogress' must be of type '(this: XMLHttpRequest, ev: ProgressEvent) => any', but here has type '(this: XMLHttpRequest, ev: Event) => any'.

    190   onprogress: ((this: XMLHttpRequest, ev: Event) => any) | null;
          ~~~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:191:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'ontimeout' must be of type '(this: XMLHttpRequest, ev: ProgressEvent) => any', but here has type '(this: XMLHttpRequest, ev: Event) => any'.

    191   ontimeout: ((this: XMLHttpRequest, ev: Event) => any) | null;
          ~~~~~~~~~

    node_modules/@types/react-native/globals.d.ts:210:6 - error TS2300: Duplicate identifier 'XMLHttpRequestResponseType'.

    210 type XMLHttpRequestResponseType = \"\" | \"arraybuffer\" | \"blob\" | \"document\" | \"json\" | \"text\";
             ~~~~~~~~~~~~~~~~~~~~~~~~~~

      node_modules/typescript/lib/lib.dom.d.ts:17308:6
        17308 type XMLHttpRequestResponseType = \"\" | \"arraybuffer\" | \"blob\" | \"document\" | \"json\" | \"text\";
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
        'XMLHttpRequestResponseType' was also declared here.

    node_modules/@types/react-native/index.d.ts:9120:11 - error TS2451: Cannot redeclare block-scoped variable 'console'.

    9120     const console: Console;
                   ~~~~~~~

      node_modules/typescript/lib/lib.dom.d.ts:17118:13
        17118 declare var console: Console;
                          ~~~~~~~
        'console' was also declared here.

    node_modules/@types/react-native/index.d.ts:9128:18 - error TS2717: Subsequent property declarations must have the same type.  Property 'geolocation' must be of type 'Geolocation', but here has type 'GeolocationStatic'.

    9128         readonly geolocation: Geolocation;
                          ~~~~~~~~~~~

    node_modules/@types/react-native/index.d.ts:9131:11 - error TS2451: Cannot redeclare block-scoped variable 'navigator'.

    9131     const navigator: Navigator;
                   ~~~~~~~~~

      node_modules/typescript/lib/lib.dom.d.ts:16944:13
        16944 declare var navigator: Navigator;
                          ~~~~~~~~~
        'navigator' was also declared here.

    node_modules/typescript/lib/lib.dom.d.ts:5367:11 - error TS2300: Duplicate identifier 'FormData'.

    5367 interface FormData {
                   ~~~~~~~~

      node_modules/@types/react-native/globals.d.ts:36:15
        36 declare class FormData {
                         ~~~~~~~~
        'FormData' was also declared here.

    node_modules/typescript/lib/lib.dom.d.ts:5377:13 - error TS2300: Duplicate identifier 'FormData'.

    5377 declare var FormData: {
                     ~~~~~~~~

      node_modules/@types/react-native/globals.d.ts:36:15
        36 declare class FormData {
                         ~~~~~~~~
        'FormData' was also declared here.

    node_modules/typescript/lib/lib.dom.d.ts:16944:13 - error TS2451: Cannot redeclare block-scoped variable 'navigator'.

    16944 declare var navigator: Navigator;
                      ~~~~~~~~~

      node_modules/@types/react-native/index.d.ts:9131:11
        9131     const navigator: Navigator;
                       ~~~~~~~~~
        'navigator' was also declared here.

    node_modules/typescript/lib/lib.dom.d.ts:17118:13 - error TS2451: Cannot redeclare block-scoped variable 'console'.

    17118 declare var console: Console;
                      ~~~~~~~

      node_modules/@types/react-native/index.d.ts:9120:11
        9120     const console: Console;
                       ~~~~~~~
        'console' was also declared here.

    node_modules/typescript/lib/lib.dom.d.ts:17155:6 - error TS2300: Duplicate identifier 'RequestInfo'.

    17155 type RequestInfo = Request | string;
               ~~~~~~~~~~~

      node_modules/@types/react-native/globals.d.ts:92:14
        92 declare type RequestInfo = Request | string;
                        ~~~~~~~~~~~
        'RequestInfo' was also declared here.

    node_modules/typescript/lib/lib.dom.d.ts:17308:6 - error TS2300: Duplicate identifier 'XMLHttpRequestResponseType'.

    17308 type XMLHttpRequestResponseType = \"\" | \"arraybuffer\" | \"blob\" | \"document\" | \"json\" | \"text\";
               ~~~~~~~~~~~~~~~~~~~~~~~~~~

      node_modules/@types/react-native/globals.d.ts:210:6
        210 type XMLHttpRequestResponseType = \"\" | \"arraybuffer\" | \"blob\" | \"document\" | \"json\" | \"text\";
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
        'XMLHttpRequestResponseType' was also declared here.

    node_modules/typescript/lib/lib.dom.iterable.d.ts:64:11 - error TS2300: Duplicate identifier 'FormData'.

    64 interface FormData {
                 ~~~~~~~~

      node_modules/@types/react-native/globals.d.ts:36:15
        36 declare class FormData {
                         ~~~~~~~~
        'FormData' was also declared here.

    test/mock-textinput.ts:2:33 - error TS2339: Property 'requireActual' does not exist on type '(name: string) => any'.

    2   const RealComponent = require.requireActual(\"TextInput\")
                                      ~~~~~~~~~~~~~
```
</p>
</details>
