### PR TITLE
Quell storybook HMR warnings

### DIFF
--- a/boilerplate/app/components/button/button.story.tsx
+++ b/boilerplate/app/components/button/button.story.tsx
@@ -14,7 +14,7 @@ const buttonTextStyleArray: TextStyle[] = [
   {color: "#a511dc"},
 ]
 
-storiesOf("Button")
+storiesOf("Button", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>

--- a/boilerplate/app/components/checkbox/checkbox.story.tsx
+++ b/boilerplate/app/components/checkbox/checkbox.story.tsx
@@ -18,7 +18,7 @@ const arrayFillStyle: ViewStyle[] = [
   {backgroundColor: "#55e0ff"},
 ]
 
-storiesOf("Checkbox")
+storiesOf("Checkbox", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behaviour", () => (
     <Story>

--- a/boilerplate/app/components/form-row/form-row.story.tsx
+++ b/boilerplate/app/components/form-row/form-row.story.tsx
@@ -14,7 +14,7 @@ const arrayStyle: ViewStyle[] = [
   {borderColor: "#32cd32"},
 ]
 
-storiesOf("FormRow")
+storiesOf("FormRow", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Assembled", () => (
     <Story>

--- a/boilerplate/app/components/header/header.story.tsx
+++ b/boilerplate/app/components/header/header.story.tsx
@@ -10,7 +10,7 @@ const VIEWSTYLE = {
   backgroundColor: color.storybookDarkBg,
 }
 
-storiesOf("Header")
+storiesOf("Header", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behavior", () => (
     <Story>

--- a/boilerplate/app/components/icon/icon.story.tsx
+++ b/boilerplate/app/components/icon/icon.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Icon } from "./icon"
 
-storiesOf("Icon")
+storiesOf("Icon", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Names", () => (
     <Story>

--- a/boilerplate/app/components/switch/switch.story.tsx
+++ b/boilerplate/app/components/switch/switch.story.tsx
@@ -46,7 +46,7 @@ const thumbOnStyle: ViewStyle[] = [
   },
 ]
 
-storiesOf("Switch")
+storiesOf("Switch", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behaviour", () => (
     <Story>

--- a/boilerplate/app/components/text-field/text-field.story.tsx
+++ b/boilerplate/app/components/text-field/text-field.story.tsx
@@ -24,7 +24,7 @@ const inputStyleArray: TextStyle[] = [
 ]
 var alertWhenFocused = true
 
-storiesOf("TextField")
+storiesOf("TextField", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Labelling", () => (
     <Story>

--- a/boilerplate/app/components/text/text.story.tsx
+++ b/boilerplate/app/components/text/text.story.tsx
@@ -14,7 +14,7 @@ const viewStyleArray: ViewStyle[] = [
   {backgroundColor: "#7fff00"},
 ]
 
-storiesOf("Text")
+storiesOf("Text", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>

--- a/boilerplate/app/components/wallpaper/wallpaper.story.tsx
+++ b/boilerplate/app/components/wallpaper/wallpaper.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Wallpaper } from "./wallpaper"
 
-storiesOf("Wallpaper")
+storiesOf("Wallpaper", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>

--- a/templates/component.story.tsx.ejs
+++ b/templates/component.story.tsx.ejs
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { <%= props.pascalName %> } from "./"
 
-storiesOf("<%= props.pascalName %>")
+storiesOf("<%= props.pascalName %>", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>


### PR DESCRIPTION
The Storybook fix for this issue https://github.com/storybooks/storybook/pull/1525
adds a warning when `storiesOf` doesn’t have a `module` parameter. This leads to warnings during the storyshots test for each of the provided Bowser components:

```
 PASS  test/storyshots.test.ts (8.026s)
  ● Console

    console.warn node_modules/@storybook/client-logger/dist/index.js:13
      Missing 'module' parameter for story with a kind of 'Text'. It will break your HMR
    console.warn node_modules/@storybook/client-logger/dist/index.js:13
      Missing 'module' parameter for story with a kind of 'Button'. It will break your HMR
    [...]
```

Any components generated with `ignite generate component` will also trigger this warning.

The `module` parameter is necessary to enable hot-module-replacement to work right:
https://github.com/storybooks/storybook/issues/2022#issuecomment-336027878

I've added it to all our components' story files, as well as to the component template.