### PR TITLE
change(i18n): Migrate to react-native-localize

### DIFF
--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -1,9 +1,12 @@
-import RNLanguages from "react-native-languages"
+import * as RNLocalize from "react-native-localize"
 import i18n from "i18n-js"
 
 const en = require("./en")
 const ja = require("./ja")
 
-i18n.locale = RNLanguages.language
 i18n.fallbacks = true
 i18n.translations = { en, ja }
+
+const fallback = { languageTag: "en", isRTL: false }
+const { languageTag } = RNLocalize.findBestAvailableLanguage(Object.keys(i18n.translations)) || fallback
+i18n.locale = languageTag

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -32,7 +32,7 @@
     "mobx-react": "5.2.8",
     "mobx-state-tree": "2.0.5",
     "ramda": "0.25.0",
-    "react-native-languages": "^3.0.0",
+    "react-native-localize": "^1.0.0",
     "i18n-js": "^3.0.11",
     "react-native-keychain": "3.0.0",
     "react-native-splash-screen": "3.1.1",

--- a/boilerplate/test/mock-react-native-languages.ts
+++ b/boilerplate/test/mock-react-native-languages.ts
@@ -1,5 +1,0 @@
-jest.mock("react-native-languages", () => {
-  return {
-    languages: () => `en`,
-  }
-})

--- a/boilerplate/test/mock-react-native-localize.ts
+++ b/boilerplate/test/mock-react-native-localize.ts
@@ -1,0 +1,8 @@
+jest.mock("react-native-localize", () => {
+  return {
+    findBestAvailableLanguage: ([language = "en"]) => ({
+      languageTag: language,
+      isRTL: false,
+    }),
+  }
+})

--- a/boilerplate/test/setup.ts
+++ b/boilerplate/test/setup.ts
@@ -5,7 +5,7 @@ import "react-native"
 import "./mock-i18n"
 import "./mock-reactotron"
 import "./mock-textinput"
-import "./mock-react-native-languages"
+import "./mock-react-native-localize"
 
 declare global {
   var __TEST__


### PR DESCRIPTION
`react-native-languages` was renamed to `react-native-localize` (https://github.com/react-native-community/react-native-localize/pull/29)