### PR TITLE
change(mobx): Update to mobx-state-tree version 3.12.2

### DIFF
--- a/boilerplate/app/models/root-store/root-store.ts
+++ b/boilerplate/app/models/root-store/root-store.ts
@@ -1,4 +1,4 @@
-import { types } from "mobx-state-tree"
+import { Instance, SnapshotOut, types } from "mobx-state-tree"
 import { NavigationStoreModel } from "../../navigation/navigation-store"
 
 /**
@@ -11,9 +11,9 @@ export const RootStoreModel = types.model("RootStore").props({
 /**
  * The RootStore instance.
  */
-export type RootStore = typeof RootStoreModel.Type
+export type RootStore = Instance<typeof RootStoreModel>
 
 /**
  * The data of an RootStore.
  */
-export type RootStoreSnapshot = typeof RootStoreModel.SnapshotType
+export type RootStoreSnapshot = SnapshotOut<typeof RootStoreModel>

--- a/boilerplate/app/navigation/navigation-store.ts
+++ b/boilerplate/app/navigation/navigation-store.ts
@@ -1,4 +1,4 @@
-import { types } from "mobx-state-tree"
+import { Instance, types } from "mobx-state-tree"
 import { RootNavigator } from "./root-navigator"
 import { NavigationActions, NavigationAction } from "react-navigation"
 import { NavigationEvents } from "./navigation-events"
@@ -27,7 +27,7 @@ export const NavigationStoreModel = NavigationEvents.named("NavigationStore")
     /**
      * the navigation state tree (Frozen here means it is immutable.)
      */
-    state: types.optional(types.frozen, DEFAULT_STATE),
+    state: types.optional(types.frozen(), DEFAULT_STATE),
   })
   .actions(self => ({
 
@@ -78,4 +78,4 @@ export const NavigationStoreModel = NavigationEvents.named("NavigationStore")
     },
   }))
 
-export type NavigationStore = typeof NavigationStoreModel.Type
+export type NavigationStore = Instance<typeof NavigationStoreModel>

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -28,9 +28,9 @@
   "dependencies": {
     "apisauce": "0.16.0",
     "lodash.throttle": "4.1.1",
-    "mobx": "4.2.1",
-    "mobx-react": "5.2.8",
-    "mobx-state-tree": "2.0.5",
+    "mobx": "^4.9.4",
+    "mobx-react": "^5.4.3",
+    "mobx-state-tree": "^3.12.2",
     "ramda": "0.25.0",
     "react-native-languages": "^3.0.0",
     "i18n-js": "^3.0.11",

--- a/templates/model.ejs
+++ b/templates/model.ejs
@@ -1,4 +1,4 @@
-import { types } from "mobx-state-tree"
+import { Instance, SnapshotOut, types } from "mobx-state-tree"
 
 /**
  * Model description here for TypeScript hints.
@@ -14,12 +14,10 @@ export const <%= props.pascalName %>Model = types
   * Useful for sensitive data like passwords, or transitive state like whether a modal is open.
 
   * Note that you'll need to import `omit` from ramda, which is already included in the project!
-  *  .actions(self => ({
-  *   postProcessSnapshot: omit(["password", "socialSecurityNumber", "creditCardNumber"]),
-  * }))
+  *  .postProcessSnapshot(omit(["password", "socialSecurityNumber", "creditCardNumber"]))
   */
 
-type <%= props.pascalName %>Type = typeof <%= props.pascalName %>Model.Type
+type <%= props.pascalName %>Type = Instance<typeof <%= props.pascalName %>Model>
 export interface <%= props.pascalName %> extends <%= props.pascalName %>Type {}
-type <%= props.pascalName %>SnapshotType = typeof <%= props.pascalName %>Model.SnapshotType
+type <%= props.pascalName %>SnapshotType = SnapshotOut<typeof <%= props.pascalName %>Model>
 export interface <%= props.pascalName %>Snapshot extends <%= props.pascalName %>SnapshotType {}


### PR DESCRIPTION
According to changelog: MST 3 is twice as fast in initializing trees with half the memory consumption compared to version 2
https://github.com/mobxjs/mobx-state-tree/blob/master/changelog.md

I couldn't update mobx to 5.9.4 due to iOS 9 doesn't support proxy (I learned it hard way).