### PR TITLE
docs: fix Markdown link syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,4 +135,4 @@ This directory will hold your Jest configs and mocks, as well as your [storyshot
 
 ## Premium Support
 
-[Ignite CLI](https://infinite.red/ignite), Ignite Andross](https://github.com/infinitered/ignite-andross), and [Ignite Bowser](https://github.com/infinitered/ignite-bowser), as open source projects, are free to use and always will be. [Infinite Red](https://infinite.red/) offers premium Ignite CLI support and general mobile app design/development services. Email us at [hello@infinite.red](mailto:hello@infinite.red) to get in touch with us for more details.
+[Ignite CLI](https://infinite.red/ignite), [Ignite Andross](https://github.com/infinitered/ignite-andross), and [Ignite Bowser](https://github.com/infinitered/ignite-bowser), as open source projects, are free to use and always will be. [Infinite Red](https://infinite.red/) offers premium Ignite CLI support and general mobile app design/development services. Email us at [hello@infinite.red](mailto:hello@infinite.red) to get in touch with us for more details.


### PR DESCRIPTION
- Fix Markdown link syntax by adding forgotten `[` character