### PR TITLE
Remove jest preset ignite

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -90,7 +90,7 @@
     },
     "setupFiles": [
       "<rootDir>/node_modules/react-native/jest/setup.js",
-      "<rootDir>/test/setup.ts",
+      "<rootDir>/test/setup.ts"
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -71,7 +71,6 @@
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-native": "^3.6.0",
     "eslint-plugin-standard": "^4.0.0",
-    "jest-preset-ignite": "0.6.1",
     "npm-run-all": "4.1.5",
     "patch-package": "5.1.1",
     "postinstall-prepare": "1.0.1",
@@ -84,9 +83,22 @@
     "typescript": "3.2.4"
   },
   "jest": {
-    "preset": "jest-preset-ignite",
-    "testPathIgnorePatterns": ["/node_modules/", "/e2e"],
-    "transformIgnorePatterns": ["node_modules/(?!(@react-native-community|react-native))"]
+    "preset": "react-native",
+    "moduleNameMapper": {
+      "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|png|psd|svg|webp|ttf|otf)$": "RelativeImageStub",
+      "^React$": "<rootDir>/node_modules/react"
+    },
+    "setupFiles": [
+      "<rootDir>/node_modules/react-native/jest/setup.js",
+      "<rootDir>/test/setup.ts",
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/e2e"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(jest-)?react-native|react-native|react-navigation|@react-navigation|@storybook|@react-native-community)"
+    ]
   },
   "prettier": {
     "printWidth": 100,


### PR DESCRIPTION
Per our conversation on Slack this removes jest-preset-ignite in favor of handling jest configuration in the bowser boilerplate package.json.