### PR TITLE
Fix for error what happening because pod install is part of the packa…

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -252,11 +252,12 @@ async function install(context) {
           "  }",
       },
     )
-
-    ignite.patchInFile(`${process.cwd()}/package.json`, {
-      replace: `"postinstall": "solidarity",`,
-      insert: `"postinstall": "solidarity && jetify && (cd ios; pod install)",`,
-    })
+    if (isMac) {
+      ignite.patchInFile(`${process.cwd()}/package.json`, {
+        replace: `"postinstall": "solidarity",`,
+        insert: `"postinstall": "solidarity && jetify && (cd ios; pod install)",`,
+      })
+    }
   } catch (e) {
     ignite.log(e)
     print.error(`


### PR DESCRIPTION
Hi, here an error description
https://infiniteredcommunity.slack.com/archives/C2PJLJP0W/p1565288237115700


By Jon Ruddell:
This error is happening because pod install is part of the package.json postinstall script.  Cocoapods isn't available for Linux and Windows.
https://infiniteredcommunity.slack.com/archives/C2PJLJP0W/p1565288614117000?thread_ts=1565288237.115700&cid=C2PJLJP0W

BR
Ilya Yulish