### PR TITLE
Fix storybook dependency problem (and a couple of others)

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -255,7 +255,7 @@ async function install(context) {
 
     ignite.patchInFile(`${process.cwd()}/package.json`, {
       replace: `"postinstall": "solidarity",`,
-      insert: `"postinstall": "solidarity && jetify && (cd ios; pod install)",`,
+      insert: `"postinstall": "solidarity && jetify && if which pod >/dev/null; then (cd ios; pod install); fi",`,
     })
   } catch (e) {
     ignite.log(e)

--- a/boilerplate/.solidarity
+++ b/boilerplate/.solidarity
@@ -17,6 +17,15 @@
         "semver": ">=9.2.0",
         "platform": "darwin"
       }
+    ],
+    "CocoaPods": [
+      {
+        "rule": "cli",
+        "binary": "pod",
+        "version": "--version",
+        "semver": ">=1.7.0",
+        "platform": "darwin"
+      }
     ]
   }
 }

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -53,6 +53,13 @@
     "@storybook/addon-storyshots": "^5.1.9",
     "@storybook/react-native": "^5.1.9",
     "babel-core": "7.0.0-bridge.0",
+<%# Work around https://github.com/storybookjs/storybook/issues/5817
+    which results in the "can yarn install and pass tests" test failing
+    with "Cannot find module 'emotion-theming' from 'index.js'".
+    If you upgrade packages, try removing these two: -%>
+    "@emotion/core": "^10.0.15",
+    "emotion-theming": "^10.0.14",
+
     "@types/jest": "24.0.16",
     "@types/ramda": "0.26.18",
     "@types/react": "16.8.23",

--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -35,7 +35,7 @@ describe("a generated app", () => {
         .shell("yarn test 2>&1")
         .then(() => execa.shell("git status --porcelain"))
         .then(({ stdout }) => expect(stdout).toEqual(""))
-        .then(() => execa.shell("yarn format && yarn lint --max-warnings 0"))
+        .then(() => execa.shell("yarn compile && yarn format && yarn lint --max-warnings 0"))
         .then(() => execa.shell("git status --porcelain")),
     ).resolves.toMatchObject({ stdout: "" }) // will fail & show the yarn or test errors
   })


### PR DESCRIPTION
When I try to generate a new project and run tests, they fail with `Cannot find module 'emotion-theming' from 'index.js'` which seems to be [this Storybook problem]( https://github.com/storybookjs/storybook/issues/5817) -- it seems like a couple of their dependencies aren't being hoisted properly, and seems to be fixed by explicitly adding them to the main project... which I've done.

Also, fixed #231 - don't run `pod install` unless the `pod` executable is available. Also, I added a Solidarity rule to check for that executable on Mac only.

Also also, fixed #199 (at least, the part I think is actionable) -- the generated-app test now explicitly verifies that `yarn compile` doesn't complain (along with the existing format & lint checks).