### PR TITLE
Fix navigation generator

### DIFF
--- a/commands/generate/navigator.js
+++ b/commands/generate/navigator.js
@@ -58,54 +58,60 @@ module.exports = {
     const pascalName = pascalCase(navigatorName)
     const camelName = camelCase(navigatorName)
 
-    const askForNavigatorType = {
-      type: "select",
-      name: "navigatorType",
-      message: "What type of navigator do you want to create?",
-      initial: "Stack",
-      choices: Object.keys(navigatorTypes),
-    }
-
-    const { navigatorType } = await ask(askForNavigatorType)
-
-    // get a list of current screens
-    const allKebabScreens = list(`${process.cwd()}/app/screens/`)
-    const allPascalScreens = allKebabScreens.map(s => pascalCase(s))
-    let pascalScreens = []
-
-    // ask which screens to include in navigator
-    if (allKebabScreens) {
-      const askForScreens = {
-        type: "multiselect",
-        name: "screens",
-        message: "What screens would you like to import to the navigator?",
-        choices: allPascalScreens,
+    // what navigator type to generate?
+    let navigatorType = parameters.options["type"]
+    if (!navigatorType) {
+      const askForNavigatorType = {
+        type: "select",
+        name: "navigatorType",
+        message: "What type of navigator do you want to create?",
+        initial: "Stack",
+        choices: Object.keys(navigatorTypes),
       }
 
-      const result = await ask(askForScreens)
-      pascalScreens = result.screens
+      const result = await ask(askForNavigatorType)
+      navigatorType = result.navigatorType
     }
 
-    // get a list of current screens
-    const allKebabNavigators = list(`${process.cwd()}/app/navigation/`).filter(
-      n => n.includes("-navigator.") && !n.includes("stateful-") && !n.includes("root-"),
-    )
-    const allPascalNavigators = allKebabNavigators.map(s =>
-      pascalCase(s.replace(".tsx", "").replace(".ts", "")),
-    )
-    let pascalNavigators = []
+    // which screens to include in the new navigator?
+    let pascalScreens = parameters.options["screens"] && parameters.options["screens"].split(",")
+    if (!pascalScreens) {
+      const allKebabScreens = list(`${process.cwd()}/app/screens/`)
+      const allPascalScreens = allKebabScreens.map(s => pascalCase(s))
 
-    // ask which screens to include in navigator
-    if (allKebabNavigators) {
-      const askForNavigators = {
-        type: "multiselect",
-        name: "screens",
-        message: "What other navigators would you like to import to the navigator?",
-        choices: allPascalNavigators,
+      if (allKebabScreens) {
+        const askForScreens = {
+          type: "multiselect",
+          name: "screens",
+          message: "What screens would you like to import to the navigator?",
+          choices: allPascalScreens,
+        }
+
+        pascalScreens = await ask(askForScreens).screens
       }
+    }
 
-      const result = await ask(askForNavigators)
-      pascalNavigators = result.screens
+    // which screens to include in navigator?
+    let pascalNavigators =
+      parameters.options["navigators"] && parameters.options["navigators"].split(",")
+    if (!pascalNavigators) {
+      const allKebabNavigators = list(`${process.cwd()}/app/navigation/`).filter(
+        n => n.includes("-navigator.") && !n.includes("stateful-") && !n.includes("root-"),
+      )
+      const allPascalNavigators = allKebabNavigators.map(s =>
+        pascalCase(s.replace(".tsx", "").replace(".ts", "")),
+      )
+
+      if (allPascalNavigators) {
+        const askForNavigators = {
+          type: "multiselect",
+          name: "navigators",
+          message: "What other navigators would you like to import to the navigator?",
+          choices: allPascalNavigators,
+        }
+
+        pascalNavigators = await ask(askForNavigators).navigators
+      }
     }
 
     const props = {

--- a/commands/generate/navigator.js
+++ b/commands/generate/navigator.js
@@ -33,7 +33,7 @@ module.exports = {
     }
 
     // grab the closest package.json
-    const packageJSON = await require("read-pkg-up")()
+    const { package: packageJSON } = await require("read-pkg-up")()
     if (!packageJSON) {
       print.error(`Can't find a package.json here or in parent directories.`)
       return

--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -78,4 +78,26 @@ describe("a generated app", () => {
     const lint = await execa("npm", ["-s", "run", "lint"])
     expect(lint.stderr).toBe("")
   })
+
+  test("generates navigation", async () => {
+    const simpleNavigation = "test"
+    await execa(
+      IGNITE,
+      [
+        "g",
+        "navigator",
+        "test",
+        "--type",
+        "Stack",
+        "--screens",
+        "DemoScreen,WelcomeScreen",
+        "--navigators",
+        "PrimaryNavigator",
+      ],
+      { preferLocal: false },
+    )
+    expect(jetpack.exists(`app/navigation/${simpleNavigation}-navigator.ts`)).toBe("file")
+    const lint = await execa("npm", ["-s", "run", "lint"])
+    expect(lint.stderr).toBe("")
+  })
 })


### PR DESCRIPTION
`ignite g navigation Test` failed with a type error: `read-pkg-up` doesn't return the package; it returns an object with {package, path}. (I did bump the `read-pkg-up` version from 5.0.0 to 6.0.0 recently, but it's not apparent from the limited release notes that the result type changed... so maybe this has been broken for a while.)

Fixes https://github.com/infinitered/ignite-bowser/issues/237.

Also added a simple test for the navigation generator. To drive the generator from the test, the generator now checks for options before asking its questions. Like the other generator tests, this one isn't exhaustive, but at least checks that the basic flow works, which'll hopefully prevent problems like this in the future.
