### PR TITLE
Properly skip `pod install` on non-Mac platforms

### DIFF
--- a/bin/maybe-pod-install
+++ b/bin/maybe-pod-install
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/**
+ * Run `pod install` if the `pod` executable exists; succeed if it succeeds or
+ * fail if it fails. If it doesn't exist, succeed quietly.
+ */
+
+const childProcess = require("child_process")
+
+// We don't want to just ignore a `pod install` failure, so to distiguish
+// "it doesn't exist" from "it exists but something went wrong", we'll
+// try to run `pod` "innocuously" first; if it succeeds, the executable exists.
+childProcess.exec("pod --version", {}, error => {
+  if (error) {
+    // `pod` doesn't exist; succeed quietly
+    process.exit(0)
+  }
+
+  // Now run it for real, and pass any error along.
+  childProcess.exec("pod install", { cwd: "ios", stdio: "inherit" }, error => {
+    if (error) {
+      console.error("pod install failed:")
+      process.exit(error.code)
+    }
+  })
+})

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -255,7 +255,7 @@ async function install(context) {
 
     ignite.patchInFile(`${process.cwd()}/package.json`, {
       replace: `"postinstall": "solidarity",`,
-      insert: `"postinstall": "solidarity && jetify && if which pod >/dev/null; then (cd ios; pod install); fi",`,
+      insert: `"postinstall": "solidarity && jetify && maybe-pod-install",`,
     })
   } catch (e) {
     ignite.log(e)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "readme.md",
     "vanilla"
   ],
+  "bin": {
+    "maybe-pod-install": "bin/maybe-pod-install"
+  },
   "author": {
     "name": "Infinite Red",
     "email": "npm@infinite.red",


### PR DESCRIPTION
... by running a script (`maybe-pod-install`) that silently succeeds if `pod` can't be found.

I've tested `ignite new MyApp -b ./bowser` on Mac and Windows, and with `yarn` installed on Windows, it succeeded. Without `yarn` installed, `npm i` couldn't find the new script - I don't know why. I didn't test further than generating a new app on Windows.

Note that I also didn't test without Yarn on Mac - this might've broken the local-boilerplate for non-yarn users (and I'm loathe to screw up my Mac development environment). Any hard-no-on-Yarn users want to test this for me?

This should fix #243 and maybe #244.