### PR TITLE
Move postInstall commands to their own script; add command to kill metro

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -256,7 +256,7 @@ async function install(context) {
 
     ignite.patchInFile(`${process.cwd()}/package.json`, {
       replace: `"postinstall": "solidarity",`,
-      insert: `"postinstall": "bin/postInstall",`,
+      insert: `"postinstall": "./bin/postInstall",`,
     })
   } catch (e) {
     ignite.log(e)

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -142,6 +142,7 @@ async function install(context) {
       template: "app/screens/demo-screen/demo-screen.tsx.ejs",
       target: "app/screens/demo-screen/demo-screen.tsx",
     },
+    { template: "bin/postInstall", target: "bin/postInstall" },
   ]
   const templateProps = {
     name,
@@ -255,7 +256,7 @@ async function install(context) {
 
     ignite.patchInFile(`${process.cwd()}/package.json`, {
       replace: `"postinstall": "solidarity",`,
-      insert: `"postinstall": "solidarity && jetify && if which pod >/dev/null; then (cd ios; pod install); fi",`,
+      insert: `"postinstall": "bin/postInstall",`,
     })
   } catch (e) {
     ignite.log(e)

--- a/boilerplate/bin/postInstall
+++ b/boilerplate/bin/postInstall
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+const childProcess = require("child_process")
+const os = require("os")
+
+/**
+ * Do all things that need to be done after installing packages
+ *
+ * Yes, it slows down package installation a little, but it's nice to not
+ * have to remember these extra steps.
+ */
+;[
+  // Make sure we're set up correctly
+  { command: "solidarity" },
+
+  // Kill the metro bundler if it's running.
+  { command: 'pkill -f "cli.js start" || set exit 0', onlyPlatforms: ["darwin", "linux"] },
+  // Help wanted: Add the windows version here. { command: "????", onlyPlatforms: ["windows"] },
+
+  // Make sure our native modules are androidX-happy
+  { command: "jetify" },
+
+  // on iOS, make sure our native modules are installed
+  { command: "pod install", cwd: "ios", onlyPlatforms: ["darwin"] },
+]
+  .filter(({ onlyPlatforms }) => !onlyPlatforms || onlyPlatforms.includes(os.platform()))
+  .forEach(commandAndOptions => {
+    const { command, onlyPlatform: _, ...options } = commandAndOptions
+    try {
+      childProcess.execSync(command, {
+        stdio: "inherit",
+        ...options,
+      })
+    } catch (error) {
+      process.exit(error.status)
+    }
+  })

--- a/boilerplate/bin/postInstall
+++ b/boilerplate/bin/postInstall
@@ -15,7 +15,7 @@ const os = require("os")
 
   // Kill the metro bundler if it's running.
   { command: 'pkill -f "cli.js start" || set exit 0', onlyPlatforms: ["darwin", "linux"] },
-  // Help wanted: Add the windows version here. { command: "????", onlyPlatforms: ["windows"] },
+  // Help wanted: Add the windows version here. { command: "????", onlyPlatforms: ["win32"] },
 
   // Make sure our native modules are androidX-happy
   { command: "jetify" },


### PR DESCRIPTION
This is an alternative to #245, which I think will work better for the long term.

This adds a new `bin/postInstall` script to do all the yarn or npm postInstall steps; it can be
smarter about what steps to run on which platforms, more generally than #245 did.

I've also added a new postInstall step: it kills any running instance of the Metro bundler when you install packages. I've had problems when I forget to do this, and it takes virtually no time. Note that it only does this on Mac or Linux because I haven't worked out the equivalent Windows incantation; HELP WANTED if a Windows person wants to try!

I've tested `ignite new MyApp -b ./bowser` on Mac and Windows.

Like the other implementation, this should fix #243 and maybe #244.