### PR TITLE
Fix windows postInstall issue

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -257,7 +257,7 @@ async function install(context) {
 
     ignite.patchInFile(`${process.cwd()}/package.json`, {
       replace: `"postinstall": "solidarity",`,
-      insert: `"postinstall": "./bin/postInstall",`,
+      insert: `"postinstall": "node ./bin/postInstall",`,
     })
   } catch (e) {
     ignite.log(e)


### PR DESCRIPTION
When trying to start a new project on Windows, I was getting an error:

```
Error: Command failed: yarn
'.\bin\postInstall' is not recognized as an internal or external command, operable program or batch file.
```

This should fix that. Tested on Windows and is working.

Related: #243 #247 