### PR TITLE
chore(docs): Added CocoaPods note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,9 @@ npm install -g ignite-cli
 yarn global add ignite-cli
 ```
 
+**Note:**
+Make sure you have [CocoaPods](https://guides.cocoapods.org/using/getting-started.html) installed because otherwise React Native installation will fail.
+
 Then spin up a new Bowser-powered React Native app:
 
 ```


### PR DESCRIPTION
I tried scaffolding new Bowser project (v4.7.4) but I always go an error saying `failed to add React Native 0.61.2` and I couldn't get pass that no matter what I tried.

After searching and trying some things I found about Ignite CLI `--debug` option where I saw that I got an error saying I'm missing CocoaPods and after I installed CocoaPods I managed to get project scaffolded without any problems.

Relates to #250 