### PR TITLE
Fix "Type alias 'RootStoreType' circularly references itself"

### DIFF
--- a/boilerplate/app/models/extensions/with-environment.ts
+++ b/boilerplate/app/models/extensions/with-environment.ts
@@ -11,7 +11,7 @@ export const withEnvironment = (self: IStateTreeNode) => ({
      * The environment.
      */
     get environment() {
-      return getEnv(self) as Environment
+      return getEnv<Environment>(self)
     },
   },
 })

--- a/boilerplate/app/models/extensions/with-root-store.ts
+++ b/boilerplate/app/models/extensions/with-root-store.ts
@@ -11,7 +11,7 @@ export const withRootStore = (self: IStateTreeNode) => ({
      * The root store.
      */
     get rootStore() {
-      return getRoot(self) as RootStore
+      return getRoot<RootStore>(self)
     },
   },
 })

--- a/boilerplate/app/models/extensions/with-status.ts
+++ b/boilerplate/app/models/extensions/with-status.ts
@@ -33,7 +33,7 @@ export const withStatus = () => {
     views: {
       // a getter
       get status() {
-        return status.get() as StatusType
+        return status.get<StatusType>()
       },
       // as setter
       set status(value: StatusType) {

--- a/boilerplate/app/models/extensions/with-status.ts
+++ b/boilerplate/app/models/extensions/with-status.ts
@@ -33,7 +33,7 @@ export const withStatus = () => {
     views: {
       // a getter
       get status() {
-        return status.get<StatusType>()
+        return status.get() as StatusType
       },
       // as setter
       set status(value: StatusType) {

--- a/boilerplate/app/models/root-store/root-store.ts
+++ b/boilerplate/app/models/root-store/root-store.ts
@@ -11,9 +11,9 @@ export const RootStoreModel = types.model("RootStore").props({
 /**
  * The RootStore instance.
  */
-export type RootStore = Instance<typeof RootStoreModel>
+export interface RootStore extends Instance<typeof RootStoreModel> {}
 
 /**
  * The data of a RootStore.
  */
-export type RootStoreSnapshot = SnapshotOut<typeof RootStoreModel>
+export interface RootStoreSnapshot extends SnapshotOut<typeof RootStoreModel> {}


### PR DESCRIPTION
Interfaces support recursion a little better than types.