### PR TITLE
feat(mobx-react): swap out mobx-react for mobx-react-lite

### DIFF
--- a/boilerplate/app/navigation/back-button-handler.tsx
+++ b/boilerplate/app/navigation/back-button-handler.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useEffect } from "react"
 import { BackHandler } from "react-native"
-import { observer } from "mobx-react"
+import { observer } from "mobx-react-lite"
 import { NavigationActions } from "react-navigation"
 import { useStores } from "../models/root-store"
 

--- a/boilerplate/app/navigation/stateful-navigator.tsx
+++ b/boilerplate/app/navigation/stateful-navigator.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { observer } from "mobx-react"
+import { observer } from "mobx-react-lite"
 // @ts-ignore: until they update @type/react-navigation
 import { getNavigation, NavigationScreenProp, NavigationState } from "react-navigation"
 import { useStores } from "../models/root-store"

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -32,7 +32,7 @@
     "apisauce": "1.0.3",
     "lodash.throttle": "4.1.1",
     "mobx": "^4.13.0",
-    "mobx-react": "^6.1.1",
+    "mobx-react-lite": "^1.4.1",
     "mobx-state-tree": "^3.14.1",
     "ramda": "0.26.1",
     "react-native-localize": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ MST is...
 - Performant
   - Round-trip store writes are much faster
   - Computed values (views) are only calculated when needed
-  - `mobx-react-light` makes React "MobX-aware" and only re-renders when absolutely necessary
+  - `mobx-react-lite` makes React "MobX-aware" and only re-renders when absolutely necessary
 - Customizable
   - MST ships with pre-built middlewares, including one which allows for [Redux interoperability](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-middlewares/README.md#redux). These middlewares can also serve as examples to create your own!
 

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ MST is...
 - Performant
   - Round-trip store writes are much faster
   - Computed values (views) are only calculated when needed
-  - `mobx-react` makes React "MobX-aware" and only re-renders when absolutely necessary
+  - `mobx-react-light` makes React "MobX-aware" and only re-renders when absolutely necessary
 - Customizable
   - MST ships with pre-built middlewares, including one which allows for [Redux interoperability](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-middlewares/README.md#redux). These middlewares can also serve as examples to create your own!
 

--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { observer } from "mobx-react"
+import { observer } from "mobx-react-light"
 import { ViewStyle } from "react-native"
 import { Text } from "../../components/text"
 import { Screen } from "../../components/screen"

--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { observer } from "mobx-react-light"
+import { observer } from "mobx-react-lite"
 import { ViewStyle } from "react-native"
 import { Text } from "../../components/text"
 import { Screen } from "../../components/screen"


### PR DESCRIPTION
Considering we've migrated to hooks, it makes sense to me to move to [mobx-react-lite](https://github.com/mobxjs/mobx-react-lite) which describes itself as the following:

> This is a next iteration of mobx-react coming from introducing React hooks which simplifies a lot of internal workings of this package.


Tested with master branch:
<img width="546" alt="image" src="https://user-images.githubusercontent.com/3880008/66737937-41724600-ee3b-11e9-8b97-ba7689f58ec4.png">
