### PR TITLE
Add test for missing i18n keys

### DIFF
--- a/boilerplate/app/components/text/text.story.tsx
+++ b/boilerplate/app/components/text/text.story.tsx
@@ -57,7 +57,7 @@ storiesOf("Text", module)
       <UseCase text="tx" usage="Used for looking up i18n keys.">
         <View style={VIEWSTYLE}>
           <Text tx="common.ok" />
-          <Text tx="omglol" />
+          <Text tx="common.cancel" />
         </View>
       </UseCase>
       <UseCase

--- a/boilerplate/test/__snapshots__/storyshots.test.ts.snap
+++ b/boilerplate/test/__snapshots__/storyshots.test.ts.snap
@@ -4281,7 +4281,7 @@ exports[`Storyshots Text Passing Content 1`] = `
                   }
                 }
               >
-                omglol.test
+                common.cancel.test
               </Text>
             </View>
           </View>

--- a/boilerplate/test/i18n.test.ts
+++ b/boilerplate/test/i18n.test.ts
@@ -1,0 +1,60 @@
+const en = require("../app/i18n/en.json")
+
+import { exec } from "child_process"
+
+// Use this array for keys that for whatever reason aren't greppable so they
+// don't hold your test suite hostage by always failing.
+const EXCEPTIONS = []
+
+/**
+ * This tests your codebase for missing i18n strings so you can avoid error strings at render time
+ *
+ * It was taken from https://gist.github.com/Michaelvilleneuve/8808ba2775536665d95b7577c9d8d5a1
+ * and modified slightly to account for our Bowser higher order components,
+ * which take 'tx' and 'fooTx' props.
+ * The grep command is nasty looking, but it's essentially searching the codebase for 3 things:
+ *
+ * tx="*"
+ * Tx=""
+ * translate(""
+ *
+ * and then grabs the i18n key between the double quotes
+ *
+ * This approach isn't 100% perfect. If you are storing your key string in a variable because you
+ * are setting it conditionally, then it won't be picked up.
+ *
+ */
+
+describe("i18n", () => {
+  test("There are no missing keys", done => {
+  // Actual command output:
+  // grep "Tx=\"\S*\"\|tx=\"\S*\"\|translate(\"\S*\"" -ohr './app' | grep -o "\".*\""
+  const command = `grep "Tx=\\"\\S*\\"\\|tx=\\"\\S*\\"\\|translate(\\"\\S*\\"" -ohr '../app' | grep -o "\\".*\\""`
+    exec(command, (_, stdout) => {
+      const allTranslationsDefined = iterate(en, "", [])
+      const allTranslationsUsed = stdout.replace(new RegExp('"', "g"), "").split("\n")
+      allTranslationsUsed.splice(-1, 1)
+
+      for (let i = 0; i < allTranslationsUsed.length; i += 1) {
+        if (!EXCEPTIONS.includes(allTranslationsUsed[i])) {
+          expect(allTranslationsDefined).toContainEqual(allTranslationsUsed[i])
+        }
+      }
+      done()
+    })
+  }, 240000)
+})
+
+function iterate(obj, stack, array) {
+  for (const property in obj) {
+    if (obj.hasOwnProperty(property)) {
+      if (typeof obj[property] === "object") {
+        iterate(obj[property], `${stack}.${property}`, array)
+      } else {
+        array.push(`${stack.slice(1)}.${property}`)
+      }
+    }
+  }
+
+  return array
+}

--- a/boilerplate/test/i18n.test.ts
+++ b/boilerplate/test/i18n.test.ts
@@ -4,7 +4,9 @@ import { exec } from "child_process"
 
 // Use this array for keys that for whatever reason aren't greppable so they
 // don't hold your test suite hostage by always failing.
-const EXCEPTIONS = []
+const EXCEPTIONS = [
+  // "welcomeScreen.readyForLaunch",
+]
 
 /**
  * This tests your codebase for missing i18n strings so you can avoid error strings at render time
@@ -37,6 +39,7 @@ describe("i18n", () => {
 
       for (let i = 0; i < allTranslationsUsed.length; i += 1) {
         if (!EXCEPTIONS.includes(allTranslationsUsed[i])) {
+          // You can add keys to EXCEPTIONS (above) if you don't want them included in the test
           expect(allTranslationsDefined).toContainEqual(allTranslationsUsed[i])
         }
       }


### PR DESCRIPTION
This adds a test that greps for missing i18n keys. 

The grep will match any of the following:
- `tx="foo.thing"`
- `rightTx="foo.thing"`
- `translate("foo.thing")`

It does not cover translation keys that are passed in as a variable, but it should cover 95% of cases. 

<img width="503" alt="Screen Shot 2019-10-22 at 8 50 12 AM" src="https://user-images.githubusercontent.com/6894653/67304635-fbeff180-f4a8-11e9-8344-90667c448966.png">
