### PR TITLE
Re-enable react-native-screens with createNativeStackNavigator 

### DIFF
--- a/boilerplate/app/app.tsx.ejs
+++ b/boilerplate/app/app.tsx.ejs
@@ -9,13 +9,12 @@ import { StatefulNavigator } from "./navigation"
 import { RootStore, RootStoreProvider, setupRootStore } from "./models/root-store"
 import { BackButtonHandler, exitRoutes } from "./navigation"
 import { contains } from "ramda"
-// import { enableScreens } from "react-native-screens"
+import { enableScreens } from "react-native-screens"
 
 // This puts screens in a native ViewController or Activity. If you want fully native
 // stack navigation, use `createNativeStackNavigator` in place of `createStackNavigator`:
 // https://github.com/kmagiera/react-native-screens#using-native-stack-navigator
-// Disabled due to this issue: https://github.com/kmagiera/react-native-screens/issues/208
-// enableScreens();
+enableScreens();
 
 /**
  * Ignore some yellowbox warnings. Some of these are for deprecated functions

--- a/boilerplate/app/navigation/primary-navigator.ts
+++ b/boilerplate/app/navigation/primary-navigator.ts
@@ -1,10 +1,10 @@
-import { createStackNavigator } from "react-navigation"
+import createNativeStackNavigator from "react-native-screens/createNativeStackNavigator"
 import {
   WelcomeScreen,
   DemoScreen,
 } from "../screens"
 
-export const PrimaryNavigator = createStackNavigator(
+export const PrimaryNavigator = createNativeStackNavigator(
   {
     welcome: { screen: WelcomeScreen },
     demo: { screen: DemoScreen },

--- a/commands/generate/navigator.js
+++ b/commands/generate/navigator.js
@@ -146,7 +146,7 @@ module.exports = {
         process.exit(1)
       }
 
-      screenImport = pascalScreens.join(',\n  ')
+      const screenImport = pascalScreens.join(',\n  ')
       await patching.patch(navFilePath, {
         before: new RegExp(patterns[patterns.constants.PATTERN_NAV_IMPORTS_SCREENS]),
         insert: `  ${screenImport},\n`,


### PR DESCRIPTION
This fixes the issue observed in #285 by using `createNativeStackNavigator` within the `primary-navigator.ts`.

In the future, `react-navigation` will contain the `createNativeStackNavigator` and we should switch to use that. Details on that are in the `@next` docs: https://reactnavigation.org/docs/en/next/native-stack-navigator.html

I did not update the navigator generator, but I want feedback on whether or not we think that should be updated.

This PR also contains a small fix that had the linter failing.