### PR TITLE
Fix `react-native link` to use npx; use `exec` instead of `spawn` to catch failures

### DIFF
--- a/boilerplate/test/i18n.test.ts
+++ b/boilerplate/test/i18n.test.ts
@@ -1,6 +1,5 @@
 const en = require("../app/i18n/en.json")
-
-import { exec } from "child_process"
+const { exec } = require("child_process")
 
 // Use this array for keys that for whatever reason aren't greppable so they
 // don't hold your test suite hostage by always failing.
@@ -29,9 +28,9 @@ const EXCEPTIONS = [
 
 describe("i18n", () => {
   test("There are no missing keys", done => {
-  // Actual command output:
-  // grep "Tx=\"\S*\"\|tx=\"\S*\"\|translate(\"\S*\"" -ohr './app' | grep -o "\".*\""
-  const command = `grep "Tx=\\"\\S*\\"\\|tx=\\"\\S*\\"\\|translate(\\"\\S*\\"" -ohr '../app' | grep -o "\\".*\\""`
+    // Actual command output:
+    // grep "Tx=\"\S*\"\|tx=\"\S*\"\|translate(\"\S*\"" -ohr './app' | grep -o "\".*\""
+    const command = `grep "Tx=\\"\\S*\\"\\|tx=\\"\\S*\\"\\|translate(\\"\\S*\\"" -ohr '../app' | grep -o "\\".*\\""`
     exec(command, (_, stdout) => {
       const allTranslationsDefined = iterate(en, "", [])
       const allTranslationsUsed = stdout.replace(new RegExp('"', "g"), "").split("\n")

--- a/boilerplate/tsconfig.json
+++ b/boilerplate/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "sourceMap": true,
     "target": "es2015",
-    "lib": ["es6"],
+    "lib": ["es7"],
     "skipLibCheck": true
   },
   "exclude": ["node_modules"],

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@semantic-release/git": "^7.0.17",
     "@types/jest": "^24.0.19",
     "@types/node": "^12.12.4",
-    "@types/ramda": "0.26.23",
+    "@types/ramda": "0.26.36",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -212,7 +212,7 @@ export const install = async (toolbox: GluegunToolbox) => {
     ignite.log("adding boilerplate to project for generator commands")
 
     const boilerplate = parameters.options.b || parameters.options.boilerplate || "ignite-bowser"
-    await system.spawn(`ignite add ${boilerplate} ${debugFlag}`, { stdio: "inherit" })
+    await system.exec(`ignite add ${boilerplate} ${debugFlag}`)
 
     ignite.log("adding react-native-gesture-handler")
     await ignite.addModule("react-native-gesture-handler", {
@@ -267,7 +267,7 @@ export const install = async (toolbox: GluegunToolbox) => {
   spinner.succeed(`Installed dependencies`)
 
   // run react-native link to link assets
-  await system.spawn("react-native link", { stdio: "ignore" })
+  await system.exec("npx react-native link")
   spinner.succeed(`Linked assets`)
 
   // for Windows, fix the settings.gradle file. Ref: https://github.com/oblador/react-native-vector-icons/issues/938#issuecomment-463296401
@@ -301,8 +301,8 @@ export const install = async (toolbox: GluegunToolbox) => {
     To get started:
 
       cd ${name}
-      react-native run-ios
-      react-native run-android${androidInfo}
+      npx react-native run-ios
+      npx react-native run-android${androidInfo}
       ignite --help
 
     ${cyan("Need additional help? Join our Slack community at http://community.infinite.red.")}

--- a/test/generators-integration.test.ts
+++ b/test/generators-integration.test.ts
@@ -45,7 +45,9 @@ describe("a generated app", () => {
       execaShell("yarn test 2>&1")
         .then(() => execaShell("git status --porcelain"))
         .then(({ stdout }) => expect(stdout).toEqual(""))
-        .then(() => execaShell("yarn compile && yarn format && yarn lint --max-warnings 0"))
+        .then(() =>
+          execaShell("yarn compile 2>&1 && yarn format 2>&1 && yarn lint --max-warnings 0 2>&1"),
+        )
         .then(() => execaShell("git status --porcelain")),
     ).resolves.toMatchObject({ stdout: "" }) // will fail & show the yarn or test errors
   })


### PR DESCRIPTION
I noticed that a new app would redscreen with an error about not being able to find the Montserrat font, and traced the problem to Bowser's attempt to `react-native link` when I didn't have the `react-native` package installed globally anymore (as recommended under "Creating a new application [in the RN Getting Started doc](https://facebook.github.io/react-native/docs/getting-started.html)).

To fix this problem, I prefixed the link command with `npx`; Ignite itself was already updated to do this, but Bowser hadn't been updated to match.

To help expose problems like this in the future, I changed the link command to use `exec` instead of `spawn`: `exec` will raise an exception on failure, where we'd need to examine the `spawn` result (two different ways!) to detect an error. Looking around, I also made this change where we're adding Bowser as a dependency of the new app, to make sure a failure there stops the boilerplate too, but I didn't change the two other uses of `spawn`, when linting and formatting, because it seemed better to treat those as warnings).

I also bumped the `@types/ramda` dependency to quiet a Typescript compiler complaint about one of its dependencies (`ts-toolbox`). (This problem might have happened to me only because of the particular collection of packages I had installed in my Bowser checkout; since we don't commit `yarn.lock`, those things aren't deterministic, sadly.)