### PR TITLE
Expo compatibility

### DIFF
--- a/boilerplate/app/app.tsx.ejs
+++ b/boilerplate/app/app.tsx.ejs
@@ -4,15 +4,13 @@
 
 import "./i18n"
 import React, { useState, useEffect } from "react"
-<% if (props.useExpo) { %>
 import { YellowBox } from "react-native"
-import { initFonts } from "./theme/fonts"
-<% } else { %>
-import { AppRegistry, YellowBox } from "react-native"
-<% } %>
 import { StatefulNavigator } from "./navigation"
 import { RootStore, RootStoreProvider, setupRootStore } from "./models/root-store"
 import { BackButtonHandler, exitRoutes } from "./navigation"
+<% if (props.useExpo) { -%>
+import { initFonts } from "./theme/fonts"
+<% } -%>
 import { contains } from "ramda"
 import { enableScreens } from "react-native-screens"
 
@@ -30,20 +28,20 @@ YellowBox.ignoreWarnings([
   "componentWillReceiveProps is deprecated",
 ])
 
+<% if (!props.useExpo) { -%>
 /**
  * Storybook still wants to use ReactNative's AsyncStorage instead of the
  * react-native-community package; this causes a YellowBox warning. This hack
  * points RN's AsyncStorage at the community one, fixing the warning. Here's the
  * Storybook issue about this: https://github.com/storybookjs/storybook/issues/6078
  */
-<% if (!props.useExpo) { %>
 const ReactNative = require("react-native")
 Object.defineProperty(ReactNative, "AsyncStorage", {
   get(): any {
     return require("@react-native-community/async-storage").default
   },
 })
-<% } %>
+<% } -%>
 
 /**
  * Are we allowed to exit the app?  This is called when the back button
@@ -56,21 +54,15 @@ const canExit = (routeName: string) => contains(routeName, exitRoutes)
 /**
  * This is the root component of our app.
  */
-<% if (!props.useExpo) { %>
-export const App: React.FunctionComponent<{}> = () => {
-<% } else { %>
 export default function App() {
-<% } %>
   const [rootStore, setRootStore] = useState<RootStore | undefined>(undefined) // prettier-ignore
   useEffect(() => {
-<% if (props.useExpo) { %>
     (async () => {
+    <% if (props.useExpo) { -%>
       await initFonts()
+    <% } -%>
       setupRootStore().then(setRootStore)
     })()
-<% } else { %>
-    setupRootStore().then(setRootStore)
-<% } %>
   }, [])
 
   // Before we show the app, we have to wait for our state to be ready.
@@ -95,23 +87,3 @@ export default function App() {
   )
 }
 
-<% if (!props.useExpo) { %>
-/**
- * This needs to match what's found in your app_delegate.m and MainActivity.java.
- */
-const APP_NAME = "<%= props.name %>"
-
-// Should we show storybook instead of our app?
-//
-// ⚠️ Leave this as `false` when checking into git.
-const SHOW_STORYBOOK = false
-
-let RootComponent = App
-if (__DEV__) {
-  // Only include Storybook if we're in dev mode
-  const { StorybookUIRoot } = require("../storybook")
-
-  if (SHOW_STORYBOOK) RootComponent = StorybookUIRoot
-}
-AppRegistry.registerComponent(APP_NAME, () => RootComponent)
-<% } %>

--- a/boilerplate/app/app.tsx.ejs
+++ b/boilerplate/app/app.tsx.ejs
@@ -36,12 +36,14 @@ YellowBox.ignoreWarnings([
  * points RN's AsyncStorage at the community one, fixing the warning. Here's the
  * Storybook issue about this: https://github.com/storybookjs/storybook/issues/6078
  */
+<% if (!props.useExpo) { %>
 const ReactNative = require("react-native")
 Object.defineProperty(ReactNative, "AsyncStorage", {
   get(): any {
     return require("@react-native-community/async-storage").default
   },
 })
+<% } %>
 
 /**
  * Are we allowed to exit the app?  This is called when the back button

--- a/boilerplate/app/app.tsx.ejs
+++ b/boilerplate/app/app.tsx.ejs
@@ -4,10 +4,11 @@
 
 import "./i18n"
 import React, { useState, useEffect } from "react"
-<% if (!props.useExpo) { %>
-import { AppRegistry, YellowBox } from "react-native"
-<% } else { %>
+<% if (props.useExpo) { %>
 import { YellowBox } from "react-native"
+import { initFonts } from "./theme/fonts"
+<% } else { %>
+import { AppRegistry, YellowBox } from "react-native"
 <% } %>
 import { StatefulNavigator } from "./navigation"
 import { RootStore, RootStoreProvider, setupRootStore } from "./models/root-store"
@@ -56,7 +57,14 @@ const canExit = (routeName: string) => contains(routeName, exitRoutes)
 export const App: React.FunctionComponent<{}> = () => {
   const [rootStore, setRootStore] = useState<RootStore | undefined>(undefined) // prettier-ignore
   useEffect(() => {
+<% if (props.useExpo) { %>
+    (async () => {
+      await initFonts()
+      setupRootStore().then(setRootStore)
+    })()
+<% } else { %>
     setupRootStore().then(setRootStore)
+<% } %>
   }, [])
 
   // Before we show the app, we have to wait for our state to be ready.

--- a/boilerplate/app/app.tsx.ejs
+++ b/boilerplate/app/app.tsx.ejs
@@ -56,7 +56,11 @@ const canExit = (routeName: string) => contains(routeName, exitRoutes)
 /**
  * This is the root component of our app.
  */
+<% if (!props.useExpo) { %>
 export const App: React.FunctionComponent<{}> = () => {
+<% } else { %>
+export default function App() {
+<% } %>
   const [rootStore, setRootStore] = useState<RootStore | undefined>(undefined) // prettier-ignore
   useEffect(() => {
 <% if (props.useExpo) { %>

--- a/boilerplate/app/app.tsx.ejs
+++ b/boilerplate/app/app.tsx.ejs
@@ -4,7 +4,11 @@
 
 import "./i18n"
 import React, { useState, useEffect } from "react"
+<% if (!props.useExpo) { %>
 import { AppRegistry, YellowBox } from "react-native"
+<% } else { %>
+import { YellowBox } from "react-native"
+<% } %>
 import { StatefulNavigator } from "./navigation"
 import { RootStore, RootStoreProvider, setupRootStore } from "./models/root-store"
 import { BackButtonHandler, exitRoutes } from "./navigation"
@@ -77,21 +81,23 @@ export const App: React.FunctionComponent<{}> = () => {
   )
 }
 
-/**
- * This needs to match what's found in your app_delegate.m and MainActivity.java.
- */
-const APP_NAME = "<%= props.name %>"
+<% if (!props.useExpo) { %>
+  /**
+   * This needs to match what's found in your app_delegate.m and MainActivity.java.
+   */
+  const APP_NAME = "<%= props.name %>"
 
-// Should we show storybook instead of our app?
-//
-// ⚠️ Leave this as `false` when checking into git.
-const SHOW_STORYBOOK = false
+  // Should we show storybook instead of our app?
+  //
+  // ⚠️ Leave this as `false` when checking into git.
+  const SHOW_STORYBOOK = false
 
-let RootComponent = App
-if (__DEV__) {
-  // Only include Storybook if we're in dev mode
-  const { StorybookUIRoot } = require("../storybook")
+  let RootComponent = App
+  if (__DEV__) {
+    // Only include Storybook if we're in dev mode
+    const { StorybookUIRoot } = require("../storybook")
 
-  if (SHOW_STORYBOOK) RootComponent = StorybookUIRoot
-}
-AppRegistry.registerComponent(APP_NAME, () => RootComponent)
+    if (SHOW_STORYBOOK) RootComponent = StorybookUIRoot
+  }
+  AppRegistry.registerComponent(APP_NAME, () => RootComponent)
+<% } %>

--- a/boilerplate/app/app.tsx.ejs
+++ b/boilerplate/app/app.tsx.ejs
@@ -96,22 +96,22 @@ export default function App() {
 }
 
 <% if (!props.useExpo) { %>
-  /**
-   * This needs to match what's found in your app_delegate.m and MainActivity.java.
-   */
-  const APP_NAME = "<%= props.name %>"
+/**
+ * This needs to match what's found in your app_delegate.m and MainActivity.java.
+ */
+const APP_NAME = "<%= props.name %>"
 
-  // Should we show storybook instead of our app?
-  //
-  // ⚠️ Leave this as `false` when checking into git.
-  const SHOW_STORYBOOK = false
+// Should we show storybook instead of our app?
+//
+// ⚠️ Leave this as `false` when checking into git.
+const SHOW_STORYBOOK = false
 
-  let RootComponent = App
-  if (__DEV__) {
-    // Only include Storybook if we're in dev mode
-    const { StorybookUIRoot } = require("../storybook")
+let RootComponent = App
+if (__DEV__) {
+  // Only include Storybook if we're in dev mode
+  const { StorybookUIRoot } = require("../storybook")
 
-    if (SHOW_STORYBOOK) RootComponent = StorybookUIRoot
-  }
-  AppRegistry.registerComponent(APP_NAME, () => RootComponent)
+  if (SHOW_STORYBOOK) RootComponent = StorybookUIRoot
+}
+AppRegistry.registerComponent(APP_NAME, () => RootComponent)
 <% } %>

--- a/boilerplate/app/i18n/i18n.ts.ejs
+++ b/boilerplate/app/i18n/i18n.ts.ejs
@@ -1,4 +1,8 @@
+<% if (props.useExpo) { -%>
+import * as Localization from "expo-localization"
+<% } else { -%>
 import * as RNLocalize from "react-native-localize"
+<% } -%>
 import i18n from "i18n-js"
 
 const en = require("./en")
@@ -8,6 +12,11 @@ i18n.fallbacks = true
 i18n.translations = { en, ja }
 
 const fallback = { languageTag: "en", isRTL: false }
+
+<% if (props.useExpo) { -%>
+i18n.locale = Localization.locale || fallback
+<% } else { -%>
 const { languageTag } =
   RNLocalize.findBestAvailableLanguage(Object.keys(i18n.translations)) || fallback
 i18n.locale = languageTag
+<% } -%>

--- a/boilerplate/app/navigation/primary-navigator.ts
+++ b/boilerplate/app/navigation/primary-navigator.ts
@@ -1,4 +1,4 @@
-import createStackNavigator from "react-navigation-stack"
+import { createStackNavigator } from "react-navigation-stack"
 import { WelcomeScreen, DemoScreen } from "../screens"
 
 export const PrimaryNavigator = createStackNavigator(

--- a/boilerplate/app/navigation/root-navigator.ts
+++ b/boilerplate/app/navigation/root-navigator.ts
@@ -1,4 +1,4 @@
-import { createStackNavigator } from "react-navigation"
+import { createStackNavigator } from "react-navigation-stack"
 import { PrimaryNavigator } from "./primary-navigator"
 
 import {} from "../screens" // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/boilerplate/app/services/reactotron/reactotron.ts.ejs
+++ b/boilerplate/app/services/reactotron/reactotron.ts.ejs
@@ -1,9 +1,9 @@
 import Tron from "reactotron-react-native"
-<% if (props.useExpo) { %>
+<% if (props.useExpo) { -%>
 import { AsyncStorage } from "react-native"
-<% } else { %>
+<% } else { -%>
 import AsyncStorage from "@react-native-community/async-storage"
-<% } %>
+<% } -%>
 import { RootStore } from "../../models/root-store/root-store"
 import { onSnapshot } from "mobx-state-tree"
 import { ReactotronConfig, DEFAULT_REACTOTRON_CONFIG } from "./reactotron-config"

--- a/boilerplate/app/services/reactotron/reactotron.ts.ejs
+++ b/boilerplate/app/services/reactotron/reactotron.ts.ejs
@@ -1,5 +1,9 @@
 import Tron from "reactotron-react-native"
+<% if (props.useExpo) { %>
+import { AsyncStorage } from "react-native"
+<% } else { %>
 import AsyncStorage from "@react-native-community/async-storage"
+<% } %>
 import { RootStore } from "../../models/root-store/root-store"
 import { onSnapshot } from "mobx-state-tree"
 import { ReactotronConfig, DEFAULT_REACTOTRON_CONFIG } from "./reactotron-config"

--- a/boilerplate/app/theme/fonts/index.ts
+++ b/boilerplate/app/theme/fonts/index.ts
@@ -1,10 +1,8 @@
 import * as Font from "expo-font"
 
 export const initFonts = async () => {
-  await Promise.all([
-    Font.loadAsync({
-      "Montserrat": require("./Montserrat-Regular.ttf"),
-      "Montserrat-Regular": require("./Montserrat-Regular.ttf"),
-    }),
-  ])
+  await Font.loadAsync({
+    "Montserrat": require("./Montserrat-Regular.ttf"),
+    "Montserrat-Regular": require("./Montserrat-Regular.ttf"),
+  })
 }

--- a/boilerplate/app/theme/fonts/index.ts
+++ b/boilerplate/app/theme/fonts/index.ts
@@ -1,0 +1,10 @@
+import * as Font from "expo-font"
+
+export const initFonts = async () => {
+  await Promise.all([
+    Font.loadAsync({
+      "Montserrat": require("./Montserrat-Regular.ttf"),
+      "Montserrat-Regular": require("./Montserrat-Regular.ttf"),
+    }),
+  ])
+}

--- a/boilerplate/app/utils/storage/storage.ts.ejs
+++ b/boilerplate/app/utils/storage/storage.ts.ejs
@@ -1,4 +1,8 @@
+<% if (props.useExpo) { %>
+import { AsyncStorage } from "react-native"
+<% } else { %>
 import AsyncStorage from "@react-native-community/async-storage"
+<% } %>
 
 /**
  * Loads a string from storage.

--- a/boilerplate/app/utils/storage/storage.ts.ejs
+++ b/boilerplate/app/utils/storage/storage.ts.ejs
@@ -1,8 +1,8 @@
-<% if (props.useExpo) { %>
+<% if (props.useExpo) { -%>
 import { AsyncStorage } from "react-native"
-<% } else { %>
+<% } else { -%>
 import AsyncStorage from "@react-native-community/async-storage"
-<% } %>
+<% } -%>
 
 /**
  * Loads a string from storage.

--- a/boilerplate/index.js.ejs
+++ b/boilerplate/index.js.ejs
@@ -7,5 +7,9 @@
 // side effect of breaking other tooling like mobile-center and react-native-rename.
 //
 // It's easier just to leave it here.
-
+<% if (props.useExpo) { %>
+import App from "./app/app.tsx"
+export default App
+<% } else { %>
 import "./app/app.tsx"
+<% } %>

--- a/boilerplate/index.js.ejs
+++ b/boilerplate/index.js.ejs
@@ -7,9 +7,27 @@
 // side effect of breaking other tooling like mobile-center and react-native-rename.
 //
 // It's easier just to leave it here.
-<% if (props.useExpo) { %>
 import App from "./app/app.tsx"
+<% if (props.useExpo) { -%>
 export default App
-<% } else { %>
-import "./app/app.tsx"
-<% } %>
+<% } else { -%>
+import { AppRegistry } from "react-native"
+/**
+ * This needs to match what's found in your app_delegate.m and MainActivity.java.
+ */
+const APP_NAME = "<%= props.name %>"
+
+// Should we show storybook instead of our app?
+//
+// ⚠️ Leave this as `false` when checking into git.
+const SHOW_STORYBOOK = false
+
+let RootComponent = App
+if (__DEV__) {
+  // Only include Storybook if we're in dev mode
+  const { StorybookUIRoot } = require("./storybook")
+
+  if (SHOW_STORYBOOK) RootComponent = StorybookUIRoot
+}
+AppRegistry.registerComponent(APP_NAME, () => RootComponent)
+<% } -%>

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -28,25 +28,25 @@
 
   },
   "dependencies": {
-    "@react-native-community/async-storage": "^1.5.1",
     "apisauce": "1.0.3",
     "lodash.throttle": "4.1.1",
     "mobx": "^4.13.0",
     "mobx-react-lite": "^1.4.1",
     "mobx-state-tree": "^3.14.1",
     "ramda": "0.26.1",
-    "react-native-localize": "^1.0.0",
     "i18n-js": "^3.0.11",
-    <% if (!props.useExpo) { -%>
-      "react-native-gesture-handler": "<%= props.reactNativeGestureHandlerVersion %>",
-    <% } -%>
-    "react-native-keychain": "3.1.3",
-    "react-navigation": "4.0.10",
     "reactotron-mst": "^3.1.1",
     "reactotron-react-native": "^4.0.0-beta.1",
-    "validate.js": "0.13.1",
-    "react-native-screens": "^2.0.0-alpha.17",
-    "react-navigation-stack": "^1.10.3"
+    <% if (!props.useExpo) { -%>
+      "@react-native-community/async-storage": "^1.5.1",
+      "react-native-gesture-handler": "<%= props.reactNativeGestureHandlerVersion %>",
+      "react-native-localize": "^1.0.0",
+      "react-native-screens": "^2.0.0-alpha.17",
+      "react-native-keychain": "3.1.3",
+      "react-navigation": "4.0.10",
+      "react-navigation-stack": "^1.10.3",
+    <% } -%>
+    "validate.js": "0.13.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.0.0",

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -78,7 +78,7 @@ export const install = async (toolbox: IgniteToolbox) => {
       printInfo(`
               We'll initiate your app using Expo. Please note that you won't be able
               to use native modules unless you "eject".
-    
+
               More info here: https://docs.expo.io/versions/latest/expokit/eject/
           `)
     }
@@ -314,6 +314,18 @@ export const install = async (toolbox: IgniteToolbox) => {
   // re-run yarn; will also install pods, because of our postInstall script.
   const installDeps = ignite.useYarn ? "yarn" : "npm install"
   await system.run(installDeps)
+
+  // install dependencies for Expo
+  ignite.log("adding Expo-compatible dependencies")
+  await system.run(`expo install \
+      @react-native-community/async-storage \
+      react-native-gesture-handler \
+      react-native-localize \
+      react-native-screens \
+      react-native-keychain \
+      react-navigation \
+      react-navigation-stack`)
+
   spinner.succeed(`Installed dependencies`)
 
   // run react-native link to link assets

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -151,6 +151,9 @@ export const install = async (toolbox: IgniteToolbox) => {
   filesystem.copy(`${boilerplatePath}/storybook`, `${process.cwd()}/storybook`, copyOpts)
   filesystem.copy(`${boilerplatePath}/bin`, `${process.cwd()}/bin`, copyOpts)
   includeDetox && filesystem.copy(`${boilerplatePath}/e2e`, `${process.cwd()}/e2e`, copyOpts)
+  if (useExpo) {
+    filesystem.remove(`${boilerplatePath}/app/theme/fonts/index.ts`)
+  }
   spinner.stop()
 
   // generate some templates

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -170,6 +170,9 @@ export const install = async (toolbox: IgniteToolbox) => {
     { template: "react-native.config.js", target: "react-native.config.js" },
     { template: "tsconfig.json", target: "tsconfig.json" },
     { template: "app/app.tsx.ejs", target: "app/app.tsx" },
+    { template: "app/i18n/i18n.ts.ejs", target: "app/i18n/i18n.ts" },
+    { template: "app/services/reactotron/reactotron.ts.ejs", target: "app/services/reactotron/reactotron.ts" },
+    { template: "app/utils/storage/storage.ts.ejs", target: "app/utils/storage/storage.ts" },
     {
       template: "app/screens/welcome-screen/welcome-screen.tsx.ejs",
       target: "app/screens/welcome-screen/welcome-screen.tsx",

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -146,14 +146,14 @@ export const install = async (toolbox: IgniteToolbox) => {
   spinner.start()
   const boilerplatePath = `${__dirname}/../boilerplate`
   const copyOpts = { overwrite: true, matching: "!*.ejs" }
-  if (!useExpo) {
-    filesystem.remove(`${boilerplatePath}/app/theme/fonts/index.ts`)
-  }
   filesystem.copy(`${boilerplatePath}/app`, `${process.cwd()}/app`, copyOpts)
   filesystem.copy(`${boilerplatePath}/test`, `${process.cwd()}/test`, copyOpts)
   filesystem.copy(`${boilerplatePath}/storybook`, `${process.cwd()}/storybook`, copyOpts)
   filesystem.copy(`${boilerplatePath}/bin`, `${process.cwd()}/bin`, copyOpts)
   includeDetox && filesystem.copy(`${boilerplatePath}/e2e`, `${process.cwd()}/e2e`, copyOpts)
+  if (!useExpo) {
+    filesystem.remove(`${process.cwd()}/app/theme/fonts/index.ts`)
+  }
   spinner.stop()
 
   // generate some templates

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -318,9 +318,8 @@ export const install = async (toolbox: IgniteToolbox) => {
   // install dependencies for Expo
   ignite.log("adding Expo-compatible dependencies")
   await system.run(`expo install \
-      @react-native-community/async-storage \
+      expo-localization \
       react-native-gesture-handler \
-      react-native-localize \
       react-native-screens \
       react-native-keychain \
       react-navigation \

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -146,14 +146,14 @@ export const install = async (toolbox: IgniteToolbox) => {
   spinner.start()
   const boilerplatePath = `${__dirname}/../boilerplate`
   const copyOpts = { overwrite: true, matching: "!*.ejs" }
+  if (!useExpo) {
+    filesystem.remove(`${boilerplatePath}/app/theme/fonts/index.ts`)
+  }
   filesystem.copy(`${boilerplatePath}/app`, `${process.cwd()}/app`, copyOpts)
   filesystem.copy(`${boilerplatePath}/test`, `${process.cwd()}/test`, copyOpts)
   filesystem.copy(`${boilerplatePath}/storybook`, `${process.cwd()}/storybook`, copyOpts)
   filesystem.copy(`${boilerplatePath}/bin`, `${process.cwd()}/bin`, copyOpts)
   includeDetox && filesystem.copy(`${boilerplatePath}/e2e`, `${process.cwd()}/e2e`, copyOpts)
-  if (useExpo) {
-    filesystem.remove(`${boilerplatePath}/app/theme/fonts/index.ts`)
-  }
   spinner.stop()
 
   // generate some templates

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -322,15 +322,16 @@ export const install = async (toolbox: IgniteToolbox) => {
   await system.run(installDeps)
 
   // install dependencies for Expo
-  ignite.log("adding Expo-compatible dependencies")
-  await system.run(`expo install \
-      expo-localization \
-      react-native-gesture-handler \
-      react-native-screens \
-      react-native-keychain \
-      react-navigation \
-      react-navigation-stack`)
-
+  if (useExpo) {
+    ignite.log("adding Expo-compatible dependencies")
+    await system.run(`expo install \
+        expo-localization \
+        react-native-gesture-handler \
+        react-native-screens \
+        react-native-keychain \
+        react-navigation \
+        react-navigation-stack`)
+  }
   spinner.succeed(`Installed dependencies`)
 
   // run react-native link to link assets


### PR DESCRIPTION
 Tested by creating an RN version and an Expo version, both works fine.

### Changes for supporting Expo
- i18n: `expo-localization`
- Fonts: `expo-font`

### TODO
- AsyncStorage: Since Expo hasn't brought in the community version yet, we need to use RN version for now even though it's deprecated.
- Keychain: Expo uses its own `expo-secure-store`. Need to employ it.