### PR TITLE
Update deps for Expo

### DIFF
--- a/boilerplate/index.js.ejs
+++ b/boilerplate/index.js.ejs
@@ -10,12 +10,12 @@
 import App from "./app/app.tsx"
 <% if (!props.useExpo) { -%>
 import { AppRegistry } from "react-native"
-<% } -%>
 
 /**
  * This needs to match what's found in your app_delegate.m and MainActivity.java.
  */
 const APP_NAME = "<%= props.name %>"
+<% } -%>
 
 // Should we show storybook instead of our app?
 //

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -349,7 +349,11 @@ export const install = async (toolbox: IgniteToolbox) => {
         react-native-screens \
         react-native-keychain \
         react-navigation \
-        react-navigation-stack`)
+        react-navigation-stack\
+        @react-native-community/masked-view \
+        react-native-safe-area-context \
+        react-native-safe-area-view \
+      `)
   }
   spinner.succeed(`Installed dependencies`)
 


### PR DESCRIPTION
- Expo needs `react-native-safe-area-context` which depends on `react-native-safe-area-view`
- `react-navigation-stack` was updated 3 hours ago, requires `@react-native-community/masked-view`