### PR TITLE
Test a generated Expo app too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       - run:
           name: Run tests
           command: yarn ci:test # this command will be added to/found in your package.json scripts
+          no_output_timeout: 15m
 
   detox:
     <<: *mac

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -83,6 +83,7 @@
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-native": "^3.6.0",
     "eslint-plugin-standard": "^4.0.0",
+    "ignite-cli": "^<%= props.igniteVersion %>",
 <% if (props.useExpo) { -%>
     "jest": "^25.1.0",
     "jest-expo": "^36.0.1",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -83,7 +83,6 @@
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-native": "^3.6.0",
     "eslint-plugin-standard": "^4.0.0",
-    "ignite-cli": "^<%= props.igniteVersion %>",
 <% if (props.useExpo) { -%>
     "jest": "^25.1.0",
     "jest-expo": "^36.0.1",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -18,7 +18,11 @@
     "hack:types-react-navigation": "rimraf node_modules/@types/react-navigation/node_modules/@types",
     "hack:types-react-native": "rimraf node_modules/@types/react-native/node_modules/@types",
     "hack:types-react-test-renderer": "rimraf node_modules/@types/react-test-renderer/node_modules/@types",
+<% if (props.useExpo) { -%>
+    "lint": "eslint app storybook test --fix --ext .js,.ts,.tsx",
+<% } else { -%>
     "lint": "eslint index.js app storybook test --fix --ext .js,.ts,.tsx",
+<% } -%>
     "patch": "patch-package",
     <%# We'll add to postinstall later in boilerplate, but it needs to be simple to start with. -%>
     "postinstall": "solidarity",

--- a/boilerplate/storybook/storybook.tsx.ejs
+++ b/boilerplate/storybook/storybook.tsx.ejs
@@ -1,7 +1,11 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useState } from "react"
 import { getStorybookUI, configure } from "@storybook/react-native"
 <% if (props.useExpo) { -%>
 import { initFonts } from "../app/theme/fonts"
+
+declare global {
+  let __TEST__
+}
 <% } -%>
 
 declare var module
@@ -14,10 +18,15 @@ const StorybookUI = getStorybookUI({
   port: 9001,
   host: "localhost",
   onDeviceUI: true,
+<% if (props.useExpo) { -%>
+  asyncStorage: null
+<% } else { -%>
   asyncStorage: require("@react-native-community/async-storage")
+<% } -%>
 })
 
 export const StorybookUIRoot: React.FunctionComponent = () => {
+  const [initialized, setInitialized] = useState(false)
   useEffect(() => {
     (async () => {
 <% if (props.useExpo) { -%>
@@ -28,8 +37,9 @@ export const StorybookUIRoot: React.FunctionComponent = () => {
         const reactotron = new Reactotron.Reactotron()
         reactotron.setup()
       }
+      setInitialized(true)
     })()
   }, [])
 
-  return <StorybookUI />
+  return (initialized) ? <StorybookUI /> : null
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format:md": "prettier --write '**/*.md'",
     "format:ts": "prettier --write '**/*.ts{,x}'",
     "lint": "eslint src test --ext .ts --fix",
-    "test": "yarn build && jest --runInBand && yarn lint && yarn clean",
+    "test": "yarn build && jest --runInBand --verbose && yarn lint && yarn clean",
     "watch": "jest --runInBand --watch",
     "coverage": "jest --runInBand --coverage",
     "ci:lint": "eslint src test --ext .ts",

--- a/test/generators-integration.test.ts
+++ b/test/generators-integration.test.ts
@@ -2,7 +2,7 @@ const execa = require("execa")
 const jetpack = require("fs-jetpack")
 const tempy = require("tempy")
 
-const IGNITE_COMMAND = "npx ignite-cli"
+const IGNITE_COMMAND = "./node_modules/.bin/ignite"
 const APP = "IntegrationTest"
 const BOILERPLATE = `${__dirname}/../`
 
@@ -33,7 +33,7 @@ expoFlags.forEach(expoFlag => {
       process.chdir(appTemp)
 
       const flags = ["--no-detox", expoFlag, "--skip-git", "--debug", "--overwrite"].join(" ")
-      await execaShell(`${IGNITE_COMMAND} new ${APP} ${flags} --boilerplate ${BOILERPLATE}`)
+      await execaShell(`npx ignite-cli new ${APP} ${flags} --boilerplate ${BOILERPLATE}`)
 
       process.chdir(APP)
 

--- a/test/generators-integration.test.ts
+++ b/test/generators-integration.test.ts
@@ -11,112 +11,120 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 800000
 
 const execaShell = (command: string, opts = {}) => execa(command, { shell: true, ...opts })
 
-describe("a generated app", () => {
-  // creates a new temp directory
-  const appTemp: string = tempy.directory()
-  beforeAll(async () => {
-    // make sure we are in the temp directory. Do the initial git commit
-    // manually, so we can set up the git user first on circleci.
-    process.chdir(appTemp)
+// Run a shell command; if it fails, expect that its output was empty, so that jest
+// shows us the error output. Return the result so we can assert further on it.
+const expectCommandToSucceed = async (command: string) => {
+  const result = await execaShell(command + " 2>&1").catch(error => error)
+  if (result.exitCode !== 0) {
+    expect(result).toMatchObject({ stdout: "" })
+  }
+  return result
+}
 
-    const flags = ["--no-detox", "--no-expo", "--skip-git", "--debug", "--overwrite"].join(" ")
-    await execaShell(`${IGNITE_COMMAND} new ${APP} ${flags} --boilerplate ${BOILERPLATE}`)
+// Do these tests for non-expo and expo apps
+const expoFlags = ["--no-expo", "--expo"]
+expoFlags.forEach(expoFlag => {
+  describe(`a generated ${expoFlag === "--expo" ? "Expo" : "non-Expo"} app`, () => {
+    // creates a new temp directory
+    const appTemp: string = tempy.directory()
+    beforeAll(async () => {
+      // make sure we are in the temp directory. Do the initial git commit
+      // manually, so we can set up the git user first on circleci.
+      process.chdir(appTemp)
 
-    process.chdir(APP)
+      const flags = ["--no-detox", expoFlag, "--skip-git", "--debug", "--overwrite"].join(" ")
+      await execaShell(`${IGNITE_COMMAND} new ${APP} ${flags} --boilerplate ${BOILERPLATE}`)
 
-    await execaShell("git init")
-    await execaShell('git config user.email "test@example.com"')
-    await execaShell("git config user.name test")
-    await execaShell("git add -A")
-    await execaShell('git commit -m "Initial commit"')
-  })
+      process.chdir(APP)
 
-  afterAll(() => {
-    // clean up generated test app
-    jetpack.remove(appTemp)
-  })
-
-  test("can yarn install and pass tests", () => {
-    return expect(
-      execaShell("yarn test 2>&1")
-        .then(() => execaShell("git status --porcelain"))
-        .then(({ stdout }) => expect(stdout).toEqual(""))
-        .then(() =>
-          execaShell("yarn compile 2>&1 && yarn format 2>&1 && yarn lint --max-warnings 0 2>&1"),
-        )
-        .then(() => execaShell("git status --porcelain"))
-        .catch(error => error),
-    ).resolves.toMatchObject({ stdout: "" }) // will fail & show the yarn or test errors
-  })
-
-  test("does have a linting script", () => {
-    expect(jetpack.read("package.json", "json").scripts.lint).toBe(
-      "eslint index.js app storybook test --fix --ext .js,.ts,.tsx",
-    )
-  })
-
-  test("generates a stateless function", async () => {
-    const statelessFunction = "Stateless"
-    await execaShell(`${IGNITE_COMMAND} g component ${statelessFunction} --stateless-function`, {
-      preferLocal: false,
+      await execaShell("git init")
+      await execaShell('git config user.email "test@example.com"')
+      await execaShell("git config user.name test")
+      await execaShell("git add -A")
+      await execaShell('git commit -m "Initial commit"')
     })
-    expect(jetpack.exists(`app/components/${statelessFunction}/${statelessFunction}.tsx`)).toBe(
-      "file",
-    )
-    expect(
-      jetpack.exists(`app/components/${statelessFunction}/${statelessFunction}.story.tsx`),
-    ).toBe("file")
-    expect(
-      jetpack.exists(`app/components/${statelessFunction}/${statelessFunction}.styles.ts`),
-    ).toBe("file")
-    const lint = await execa("npm", ["-s", "run", "lint"])
-    expect(lint.stderr).toBe("")
-  })
 
-  test("generates a function component", async () => {
-    const functionComponent = "FunctionComponent"
-    await execaShell(`${IGNITE_COMMAND} g component ${functionComponent} --function-component`, {
-      preferLocal: false,
+    // clean up generated files between tests; clean up the generated test app when we're done
+    afterEach(() => execaShell("git clean -fd; git reset --hard HEAD"))
+    afterAll(() => jetpack.remove(appTemp))
+
+    test("passes tests", () => {
+      return expectCommandToSucceed("yarn test")
     })
-    expect(jetpack.exists(`app/components/${functionComponent}/${functionComponent}.tsx`)).toBe(
-      "file",
-    )
-    expect(
-      jetpack.exists(`app/components/${functionComponent}/${functionComponent}.story.tsx`),
-    ).toBe("file")
-    expect(
-      jetpack.exists(`app/components/${functionComponent}/${functionComponent}.styles.ts`),
-    ).toBe("file")
-    const lint = await execa("npm", ["-s", "run", "lint"])
-    expect(lint.stderr).toBe("")
-  })
 
-  test("generates a screen", async () => {
-    const simpleScreen = "test"
-    await execaShell(`${IGNITE_COMMAND} g screen ${simpleScreen}`, { preferLocal: false })
-    expect(jetpack.exists(`app/screens/${simpleScreen}-screen.tsx`)).toBe("file")
-    const lint = await execa("npm", ["-s", "run", "lint"])
-    expect(lint.stderr).toBe("")
-  })
+    test("compiles successfully", () => {
+      return expectCommandToSucceed("yarn compile")
+    })
 
-  test("generates a model", async () => {
-    const simpleModel = "test"
-    await execaShell(`${IGNITE_COMMAND} g model ${simpleModel}`, { preferLocal: false })
-    expect(jetpack.exists(`app/models/${simpleModel}/${simpleModel}.ts`)).toBe("file")
-    expect(jetpack.exists(`app/models/${simpleModel}/${simpleModel}.test.ts`)).toBe("file")
-    expect(jetpack.exists(`app/models/${simpleModel}/index.ts`)).toBe("file")
-    const lint = await execa("npm", ["-s", "run", "lint"])
-    expect(lint.stderr).toBe("")
-  })
+    test("lints successfully", () => {
+      return expectCommandToSucceed("yarn lint --max-warnings 0")
+    })
 
-  test("generates navigation", async () => {
-    const simpleNavigation = "test"
-    await execaShell(
-      `${IGNITE_COMMAND} g navigator test --type Stack --screens DemoScreen,WelcomeScreen --navigators PrimaryNavigator`,
-      { preferLocal: false },
-    )
-    expect(jetpack.exists(`app/navigation/${simpleNavigation}-navigator.ts`)).toBe("file")
-    const lint = await execa("npm", ["-s", "run", "lint"])
-    expect(lint.stderr).toBe("")
+    test("doesn't need reformatting", async () => {
+      await expectCommandToSucceed("yarn format")
+      // Make sure format didn't change anything
+      const { stdout } = await expectCommandToSucceed("git status --porcelain")
+      expect(stdout).toEqual("")
+    })
+
+    test("generates a stateless function", async () => {
+      const statelessFunction = "Stateless"
+      await execaShell(`${IGNITE_COMMAND} g component ${statelessFunction} --stateless-function`, {
+        preferLocal: false,
+      })
+      expect(jetpack.exists(`app/components/${statelessFunction}/${statelessFunction}.tsx`)).toBe(
+        "file",
+      )
+      expect(
+        jetpack.exists(`app/components/${statelessFunction}/${statelessFunction}.story.tsx`),
+      ).toBe("file")
+      expect(
+        jetpack.exists(`app/components/${statelessFunction}/${statelessFunction}.styles.ts`),
+      ).toBe("file")
+      await expectCommandToSucceed("yarn lint")
+    })
+
+    test("generates a function component", async () => {
+      const functionComponent = "FunctionComponent"
+      await execaShell(`${IGNITE_COMMAND} g component ${functionComponent} --function-component`, {
+        preferLocal: false,
+      })
+      expect(jetpack.exists(`app/components/${functionComponent}/${functionComponent}.tsx`)).toBe(
+        "file",
+      )
+      expect(
+        jetpack.exists(`app/components/${functionComponent}/${functionComponent}.story.tsx`),
+      ).toBe("file")
+      expect(
+        jetpack.exists(`app/components/${functionComponent}/${functionComponent}.styles.ts`),
+      ).toBe("file")
+      await expectCommandToSucceed("yarn lint")
+    })
+
+    test("generates a screen", async () => {
+      const simpleScreen = "test"
+      await execaShell(`${IGNITE_COMMAND} g screen ${simpleScreen}`, { preferLocal: false })
+      expect(jetpack.exists(`app/screens/${simpleScreen}-screen.tsx`)).toBe("file")
+      await expectCommandToSucceed("yarn lint")
+    })
+
+    test("generates a model", async () => {
+      const simpleModel = "test"
+      await execaShell(`${IGNITE_COMMAND} g model ${simpleModel}`, { preferLocal: false })
+      expect(jetpack.exists(`app/models/${simpleModel}/${simpleModel}.ts`)).toBe("file")
+      expect(jetpack.exists(`app/models/${simpleModel}/${simpleModel}.test.ts`)).toBe("file")
+      expect(jetpack.exists(`app/models/${simpleModel}/index.ts`)).toBe("file")
+      await expectCommandToSucceed("yarn lint")
+    })
+
+    test("generates navigation", async () => {
+      const simpleNavigation = "test"
+      await execaShell(
+        `${IGNITE_COMMAND} g navigator test --type Stack --screens DemoScreen,WelcomeScreen --navigators PrimaryNavigator`,
+        { preferLocal: false },
+      )
+      expect(jetpack.exists(`app/navigation/${simpleNavigation}-navigator.ts`)).toBe("file")
+      await expectCommandToSucceed("yarn lint")
+    })
   })
 })

--- a/test/generators-integration.test.ts
+++ b/test/generators-integration.test.ts
@@ -2,7 +2,7 @@ const execa = require("execa")
 const jetpack = require("fs-jetpack")
 const tempy = require("tempy")
 
-const IGNITE_COMMAND = "./node_modules/.bin/ignite"
+const IGNITE_COMMAND = "npx ignite-cli"
 const APP = "IntegrationTest"
 const BOILERPLATE = `${__dirname}/../`
 
@@ -33,7 +33,7 @@ expoFlags.forEach(expoFlag => {
       process.chdir(appTemp)
 
       const flags = ["--no-detox", expoFlag, "--skip-git", "--debug", "--overwrite"].join(" ")
-      await execaShell(`npx ignite-cli new ${APP} ${flags} --boilerplate ${BOILERPLATE}`)
+      await execaShell(`${IGNITE_COMMAND} new ${APP} ${flags} --boilerplate ${BOILERPLATE}`)
 
       process.chdir(APP)
 


### PR DESCRIPTION
Generate & test an Expo app too; break up the main test into individual tests, and clean up between them.

- Wrapped all the generated tests to run them with & without Expo
- Added a utility function, expectCommandToSucceed, that enables nice simple individual tests
- Added an afterEach to clean up generated files between tests
- Added --verbose to the test command; seeing individual test progress was useful in debugging
- Removed the test for a linting script; since expo & non-expo use different commands now, didn't seem worth the complication.
- Fixed a couple of problems found by the test changes, and a race condition in storybook startup in the expo app

The bad news: after the above, test suite runtime went from 5.2m to 11.2m for me - makes sense it'd about double since we're generating a second app once, and running each of the slow generated-stuff tests twice. (I also had to increase CircleCI's timeout to get it to pass this branch.) I tried making ignite-cli a devDependency of the generated app so that I could run ignite in the tests without `npx`, but that didn't work right, so I reverted it.