### PR TITLE
add screen folder to generate screen command

### DIFF
--- a/src/commands/generate/screen.ts
+++ b/src/commands/generate/screen.ts
@@ -30,7 +30,7 @@ export const run = async function(toolbox: GluegunToolbox) {
   const jobs = [
     {
       template: `screen.ejs`,
-      target: `app/screens/${screenName}.tsx`,
+      target: `app/screens/${screenName}/${screenName}.tsx`,
     },
   ]
 

--- a/test/generators-integration.test.ts
+++ b/test/generators-integration.test.ts
@@ -94,7 +94,7 @@ describe("a generated app", () => {
   test("generates a screen", async () => {
     const simpleScreen = "test"
     await execaShell(`${IGNITE_COMMAND} g screen ${simpleScreen}`, { preferLocal: false })
-    expect(jetpack.exists(`app/screens/${simpleScreen}-screen.tsx`)).toBe("file")
+    expect(jetpack.exists(`app/screens/${simpleScreen}-screen/${simpleScreen}-screen.tsx`)).toBe("file")
     const lint = await execa("npm", ["-s", "run", "lint"])
     expect(lint.stderr).toBe("")
   })


### PR DESCRIPTION
Added a folder to the generate command that will place the newly generated screen in a folder without having to specify a folder as an argument.

Believe this also fixes issue in ignite-cli [#1536](https://github.com/infinitered/ignite/issues/1536)