### PR TITLE
Fix screen template: useStores() comments

### DIFF
--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -17,7 +17,9 @@ const ROOT: ViewStyle = {
 }
 
 export const <%= props.pascalName %>: React.FunctionComponent<<%= props.pascalName %>Props> = observer((props) => {
-  // const { someStore } = useStores()
+  // const { someStore, anotherStore } = useStores()
+  // OR
+  // const rootStore = useStores()
   return (
     <Screen style={ROOT} preset="scroll">
       <Text preset="header" tx="<%= props.camelName %>.header" />


### PR DESCRIPTION
uncommenting the line `const { someStore } = useStores()` in a newly created project gives an unintuitive **TypeError**.  
I understand that the use of rootStore may be discouraged, but it may be useful for beginners at least to add a line that works as is when uncommented.
By the way, are 3 lines too much?