### PR TITLE
Fix Storybook instructions in README.md

### DIFF
--- a/boilerplate/README.md
+++ b/boilerplate/README.md
@@ -129,7 +129,7 @@ This directory will hold your Jest configs and mocks, as well as your [storyshot
 From the command line in your generated app's root directory, enter `yarn run storybook`
 This starts up the storybook server.
 
-In `app/app.tsx`, change `SHOW_STORYBOOK` to `true` and reload the app.
+In `index.js`, change `SHOW_STORYBOOK` to `true` and reload the app.
 
 For Visual Studio Code users, there is a handy extension that makes it easy to load Storybook use cases into a running emulator via tapping on items in the editor sidebar. Install the `React Native Storybook` extension by `Orta`, hit `cmd + shift + P` and select "Reconnect Storybook to VSCode". Expand the STORYBOOK section in the sidebar to see all use cases for components that have `.story.tsx` files in their directories.
 


### PR DESCRIPTION
The SHOW_STORYBOOK variable is located in `index.js`, not `app/app.tsx` 🙂