### PR TITLE
Removes duplicate @react-native-community/async-storage

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -45,14 +45,13 @@
     "@react-navigation/native": "^5.1.5",
   <% if(props.useExpo){ %>
     "@react-navigation/stack": "^5.2.10",
-  <% } else { -%>  
-    "@react-native-community/async-storage": "^1.5.1",
+  <% } else { -%>
+    "@react-native-community/async-storage": "^1.11.0",
     "@react-native-community/masked-view": "0.1.5",
     "react-native-safe-area-view": "1.0.0",
     "react-native-gesture-handler": "<%= props.reactNativeGestureHandlerVersion %>",
     "react-native-localize": "^1.0.0",
     "react-native-keychain": "5.0.1",
-    "@react-native-community/async-storage": "^1.9.0",
   <% } -%>
     "validate.js": "0.13.1"
   },


### PR DESCRIPTION
Seems in the `package.json` file we were asking for `@react-native-community/async-storage` twice. This removes the duplication and upgrades the module to `^1.11.0`