### PR TITLE
Fixed template path bug.

### DIFF
--- a/templates/styles.ts.ejs
+++ b/templates/styles.ts.ejs
@@ -1,5 +1,5 @@
 import { ViewStyle, TextStyle } from "react-native"
-import { color, typography } from "../theme"
+import { color, typography } from "../../theme"
 
 export const <%= props.camelCaseName %>Styles = {
   WRAPPER: {


### PR DESCRIPTION
This fixes a bug when generating components:

**Steps to reproduce:** 

- Follow the steps at https://github.com/infinitered/ignite in the "Use Ignite Bowser" section, using defaults throughout.

- Run "react-native start" 

- react-native run-android

**Result:** 

"error: Error: Unable to resolve module `../theme` from `app/components/pizza-location/pizza-location.styles.ts`"

