### PR TITLE
Bump dependencies (merge AFTER the 0.63 bump)

### DIFF
--- a/boilerplate/app/utils/ignore-warnings.ts
+++ b/boilerplate/app/utils/ignore-warnings.ts
@@ -2,10 +2,9 @@
  * Ignore some yellowbox warnings. Some of these are for deprecated functions
  * that we haven't gotten around to replacing yet.
  */
-import { YellowBox } from "react-native"
+import { LogBox } from "react-native"
 
-YellowBox.ignoreWarnings([
-  "componentWillMount is deprecated",
-  "componentWillReceiveProps is deprecated",
+// prettier-ignore
+LogBox.ignoreLogs([
   "Require cycle:",
 ])

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -61,8 +61,13 @@
     "@storybook/addon-storyshots": "5.3.19",
     "@storybook/react-native": "5.3.19",
     "@storybook/react-native-server": "5.3.19",
+    "@types/jest": "^25.2.3",
     "@types/ramda": "0.26.44",
     "@types/react": "16.9.23",
+    "@types/react-native": "^0.63.2",
+    "@types/react-test-renderer": "^16.9.2",
+    "@typescript-eslint/eslint-plugin": "^2.27.0",
+    "@typescript-eslint/parser": "^2.27.0",
 <% if (props.includeDetox) { -%>
     "detox": "^16.0.0",
 <% } -%>
@@ -83,6 +88,7 @@
     "npm-run-all": "4.1.5",
     "patch-package": "6.2.2",
     "postinstall-prepare": "1.0.1",
+    "prettier": "^2.0.4",
     "react-devtools-core": "4.8.2",
     "react-powerplug": "1.0.0",
     "rimraf": "3.0.2",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -30,48 +30,43 @@
     "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081"
   },
   "dependencies": {
-    "apisauce": "1.1.1",
+    "apisauce": "1.1.2",
     "i18n-js": "^3.0.11",
     "lodash.throttle": "4.1.1",
     "mobx": "^4.15.4",
     "mobx-react-lite": "^1.4.1",
     "mobx-state-tree": "^3.14.1",
-    "ramda": "0.27.0",
+    "ramda": "0.27.1",
     "react-native-splash-screen": "3.2.0",
     "reactotron-mst": "^3.1.1",
-    "reactotron-react-native": "^4.0.0-beta.1",
-    "react-native-screens": "^2.5.0",
+    "reactotron-react-native": "^5.0.0",
+    "react-native-screens": "^2.10.1",
     "react-native-safe-area-context": "0.7.3",
     "@react-navigation/native": "^5.1.5",
   <% if(props.useExpo){ %>
     "@react-navigation/stack": "^5.2.10",
   <% } else { -%>
     "@react-native-community/async-storage": "^1.11.0",
-    "@react-native-community/masked-view": "0.1.5",
-    "react-native-safe-area-view": "1.0.0",
+    "@react-native-community/masked-view": "0.1.10",
+    "react-native-safe-area-view": "1.1.1",
     "react-native-gesture-handler": "<%= props.reactNativeGestureHandlerVersion %>",
     "react-native-localize": "^1.0.0",
-    "react-native-keychain": "5.0.1",
+    "react-native-keychain": "6.1.1",
   <% } -%>
     "validate.js": "0.13.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-    "@storybook/addon-storyshots": "5.3.17",
-    "@storybook/react-native": "5.3.17",
-    "@storybook/react-native-server": "5.3.17",
-    "@types/jest": "25.2.2",
+    "@storybook/addon-storyshots": "5.3.19",
+    "@storybook/react-native": "5.3.19",
+    "@storybook/react-native-server": "5.3.19",
     "@types/ramda": "0.26.44",
     "@types/react": "16.9.23",
-    "@types/react-native": "0.61.23",
-    "@types/react-test-renderer": "16.9.2",
-    "@typescript-eslint/eslint-plugin": "^2.24.0",
-    "@typescript-eslint/parser": "^2.24.0",
 <% if (props.includeDetox) { -%>
     "detox": "^16.0.0",
 <% } -%>
-    "eslint": "^6.6.0",
+    "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.15.0",
@@ -82,18 +77,17 @@
     "eslint-plugin-standard": "^4.0.0",
     "jest": "25.5.4",
 <% if (props.useExpo) { -%>
-    "jest-expo": "^36.0.1",
+    "jest-expo": "^38.0.2",
 <% } -%>
-    "jetifier": "^1.6.1",
+    "jetifier": "^1.6.2",
     "npm-run-all": "4.1.5",
-    "patch-package": "6.2.1",
+    "patch-package": "6.2.2",
     "postinstall-prepare": "1.0.1",
-    "prettier": "1.19.1",
-    "react-devtools-core": "4.5.0",
+    "react-devtools-core": "4.8.2",
     "react-powerplug": "1.0.0",
     "rimraf": "3.0.2",
-    "solidarity": "2.3.1",
-    "typescript": "3.9.3"
+    "solidarity": "3.0.0",
+    "typescript": "3.9.7"
   },
   "jest": {
 <% if (!props.useExpo) { -%>

--- a/boilerplate/storybook/views/use-case.tsx
+++ b/boilerplate/storybook/views/use-case.tsx
@@ -45,12 +45,13 @@ export interface UseCaseProps {
 }
 
 export function UseCase(props: UseCaseProps) {
-  const style = {
+  const style: ViewStyle = {
     ...COMPONENT,
     ...{ padding: props.noPad ? 0 : 10 },
     ...{ backgroundColor: props.noBackground ? "rgba(0,0,0,0)" : COMPONENT.backgroundColor },
     ...props.style,
   }
+
   return (
     <View style={ROOT}>
       <View style={HEADER}>


### PR DESCRIPTION
I tested @nirre7's #362 PR and noticed that (as usual) some dependencies could be bumped with it.

Tested for both --expo and --no-expo; only tested with --no-detox, though.