### PR TITLE
Fix #367 - Use YellowBox with Expo

### DIFF
--- a/boilerplate/app/utils/ignore-warnings.ts.ejs
+++ b/boilerplate/app/utils/ignore-warnings.ts.ejs
@@ -2,9 +2,18 @@
  * Ignore some yellowbox warnings. Some of these are for deprecated functions
  * that we haven't gotten around to replacing yet.
  */
+ <% if (props.useExpo) { -%>
+import { YellowBox } from "react-native"
+
+// prettier-ignore
+YellowBox.ignoreWarnings([
+  "Require cycle:",
+])
+<% } else { -%>
 import { LogBox } from "react-native"
 
 // prettier-ignore
 LogBox.ignoreLogs([
   "Require cycle:",
 ])
+<% } -%>

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -64,7 +64,11 @@
     "@types/jest": "^25.2.3",
     "@types/ramda": "0.26.44",
     "@types/react": "16.9.23",
+  <% if (props.useExpo) { -%>
+    "@types/react-native": "0.61.23",
+    <% } else { -%>
     "@types/react-native": "^0.63.2",
+  <% } -%>
     "@types/react-test-renderer": "^16.9.2",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",

--- a/src/boilerplate.ts
+++ b/src/boilerplate.ts
@@ -197,6 +197,7 @@ And here: https://guides.cocoapods.org/using/getting-started.html
       template: "app/services/reactotron/reactotron.ts.ejs",
       target: "app/services/reactotron/reactotron.ts",
     },
+    { template: "app/utils/ignore-warnings.ts.ejs", target: "app/utils/ignore-warnings.ts" },
     { template: "app/utils/storage/storage.ts.ejs", target: "app/utils/storage/storage.ts" },
     {
       template: "app/utils/storage/storage.test.ts.ejs",


### PR DESCRIPTION
Fixes an error introduced in Bowser 5.3 when using Expo. 
More details: https://github.com/infinitered/ignite-bowser/issues/367 

The following changes makes the boilerplate work again with and without Expo.

|  | React Native | Expo |  Comment |
| --------------- | --------------- | --------------- | --------------- |
| @types/react-native | 0.63.2 | 0.61.23 | |
| react-native | 0.63.2 | 0.62 | https://github.com/expo/react-native/archive/sdk-38.0.2.tar.gz |
| LogBox | Yes | No | |
| YellowBox | No | Yes | |