### PR TITLE
Added detox e2e testing for Expo apps

### DIFF
--- a/boilerplate/README.md.ejs
+++ b/boilerplate/README.md.ejs
@@ -144,6 +144,12 @@ In `index.js`, change `SHOW_STORYBOOK` to `true` and reload the app.
 <% } -%>
 For Visual Studio Code users, there is a handy extension that makes it easy to load Storybook use cases into a running emulator via tapping on items in the editor sidebar. Install the `React Native Storybook` extension by `Orta`, hit `cmd + shift + P` and select "Reconnect Storybook to VSCode". Expand the STORYBOOK section in the sidebar to see all use cases for components that have `.story.tsx` files in their directories.
 
+<% if (props.useExpo && props.includeDetox) { -%>
+## Running e2e tests
+
+Read [e2e setup instructions](./e2e/README.md)
+<% } -%>
+
 ## Previous Boilerplates
 
 - [2017 aka Andross](https://github.com/infinitered/ignite-andross)

--- a/boilerplate/app/screens/welcome-screen/welcome-screen.tsx.ejs
+++ b/boilerplate/app/screens/welcome-screen/welcome-screen.tsx.ejs
@@ -69,7 +69,12 @@ const CONTINUE_TEXT: TextStyle = {
   fontSize: 13,
   letterSpacing: 2,
 }
+
+<% if (props.useExpo && props.includeDetox) { -%>
+const FOOTER: ViewStyle = { backgroundColor: "#20162D", marginBottom: 64 }
+<% } else { -%>
 const FOOTER: ViewStyle = { backgroundColor: "#20162D" }
+<% } -%>
 const FOOTER_CONTENT: ViewStyle = {
   paddingVertical: spacing[4],
   paddingHorizontal: spacing[4],

--- a/boilerplate/bin/downloadExpoApp.sh
+++ b/boilerplate/bin/downloadExpoApp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+# taken from https://github.com/expo/with-detox-tests/blob/master/setup.sh
+
+# query expo.io to find most recent ipaUrl
+IPA_URL=`curl https://expo.io/--/api/v2/versions |  python -c 'import sys, json; print json.load(sys.stdin)["iosUrl"]'`
+
+# download tar.gz
+TMP_PATH=./exponent.tar.gz
+wget -O $TMP_PATH $IPA_URL
+
+# recursively make app dir
+APP_PATH=./bin/Exponent.app
+mkdir -p $APP_PATH
+
+# unzip tar.gz into APP_PATH
+tar -C $APP_PATH -xzf $TMP_PATH
+rm ./exponent.tar.gz

--- a/boilerplate/e2e/README.md.ejs
+++ b/boilerplate/e2e/README.md.ejs
@@ -45,6 +45,16 @@ Note that in order to pick up elements by ID, we've added the `testID` prop to t
 yarn start
 ```
 
+<% if (props.useExpo && props.includeDetox) { -%>
+For testing [production code](https://docs.expo.io/workflow/development-mode/#production-mode), start the packager with `--no-dev --minify`
+
+```
+yarn start --no-dev --minify
+```
+
+2. Run the tests
+
+<% } else { -%>
 2. Run the app
 
 In a separate terminal window from the packager:
@@ -54,6 +64,7 @@ yarn build:e2e
 ```
 
 3. Run the tests
+<% } -%>
 
 ```
 yarn test:e2e

--- a/boilerplate/e2e/firstTest.spec.ejs
+++ b/boilerplate/e2e/firstTest.spec.ejs
@@ -1,9 +1,17 @@
 // For more info on how to write Detox tests, see the official docs:
 // https://github.com/wix/Detox/blob/master/docs/README.md
 
+<% if (props.useExpo) { -%>
+const { reloadApp } = require("detox-expo-helpers")
+<% } -%>
+
 describe("Example", () => {
   beforeEach(async () => {
+<% if (props.useExpo) { -%>
+      await reloadApp()
+<% } else { -%>
     await device.reloadReactNative()
+<% } -%>
   })
 
   it("should have welcome screen", async () => {

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-<% if (props.includeDetox) { -%>
+<% if (!props.useExpo && props.includeDetox) { -%>
     "test:e2e": "detox test -c ios.sim.debug",
     "build:e2e": "detox build -c ios.sim.debug",
     "ci:test:e2e": "detox test -c ios.sim.release -l verbose --cleanup",
@@ -30,6 +30,10 @@
     "storybook": "start-storybook -p 9001 -c ./storybook",
 <% if (props.useExpo) { -%>
     "test": "jest",
+<% } -%>
+<% if (props.includeDetox && props.useExpo) { -%>
+    "test:e2e": "detox test --configuration ios.sim",
+    "downloadExpoApp": "./bin/downloadExpoApp.sh",
 <% } -%>
     "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081"
   },
@@ -78,7 +82,13 @@
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
 <% if (props.includeDetox) { -%>
+  <% if (props.useExpo) { -%>
+    "expo-detox-hook": "^1.0.10",
+    "detox-expo-helpers": "^0.6.0",
+    "detox": "^17.6.1",
+  <% } else { -%>
     "detox": "^16.0.0",
+  <% } -%>
 <% } -%>
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.0.0",
@@ -146,18 +156,26 @@
   "detox": {
     "test-runner": "jest",
     "configurations": {
-      "ios.sim.debug": {
-        "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/<%= props.name %>.app",
-        "build": "xcodebuild -workspace ios/<%= props.name %>.xcworkspace -scheme <%= props.name %> -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
-        "type": "ios.simulator",
-        "name": "iPhone 8"
-      },
-      "ios.sim.release": {
-        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/<%= props.name %>.app",
-        "build": "xcodebuild -workspace ios/<%= props.name %>.xcworkspace -scheme <%= props.name %> -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
-        "type": "ios.simulator",
-        "name": "iPhone 8"
-      }
+      <% if (!props.useExpo) { -%>
+        "ios.sim.debug": {
+          "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/<%= props.name %>.app",
+          "build": "xcodebuild -workspace ios/<%= props.name %>.xcworkspace -scheme <%= props.name %> -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
+          "type": "ios.simulator",
+          "name": "iPhone 8"
+        },
+        "ios.sim.release": {
+          "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/<%= props.name %>.app",
+          "build": "xcodebuild -workspace ios/<%= props.name %>.xcworkspace -scheme <%= props.name %> -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
+          "type": "ios.simulator",
+          "name": "iPhone 8"
+        }
+      <% } else { -%>
+        "ios.sim": {
+          "binaryPath": "bin/Exponent.app",
+          "type": "ios.simulator",
+          "name": "iPhone 11"
+        }
+      <% } -%>
     }
   },
 <% } -%>


### PR DESCRIPTION
Added detox e2e tests for Expo projects. [only iOS]  
Fixes https://github.com/infinitered/ignite-bowser/pull/299

I have made least amount of changes to get it working. 
One thing i want to mention though, the latest version of detox specifically checks for the visibility of the element and on the welcome screen `welcome-screen.tsx`, the `Continue` button at the bottom was being hidden by the `LogBox` popup that appears after the app opens, giving the following error
```
Test Failed: View “<RCTView: 0x7fa08ded38f0>” is not visible: view does not pass visibility threshold (75%)
TIP: To print view hierarchy on failed actions/matches, use loglevel verbose and above.
```
So i have added some `marginBottom` to make the button properly visible as in the below image
`const FOOTER: ViewStyle = { backgroundColor: "#20162D", marginBottom: 64 }`
<img width="584" alt="Screenshot 2020-09-29 at 1 23 55 PM" src="https://user-images.githubusercontent.com/4496555/94556974-9345f300-027b-11eb-9450-4cefebc4cf4f.png">
Expo application is downloaded during the generation of the project and placed in `bin/`

![expo-detox-e2e](https://user-images.githubusercontent.com/4496555/94568335-fdfe2b00-0289-11eb-8833-08e41f9066ee.gif)
