### PR TITLE
fix model generation adding ModelModel to name

### DIFF
--- a/src/commands/generate/model.ts
+++ b/src/commands/generate/model.ts
@@ -14,7 +14,7 @@ export const run = async function(toolbox: GluegunToolbox) {
   }
 
   // get permutations of the given model name
-  const givenName = parameters.first
+  const givenName = parameters.first.includes("-model") ? parameters.first.replace("-model", "") : parameters.first
   const name = kebabCase(givenName)
   const pascalName = pascalCase(givenName)
   const camelName = camelCase(givenName)

--- a/templates/model.ejs
+++ b/templates/model.ejs
@@ -3,7 +3,7 @@ import { Instance, SnapshotOut, types } from "mobx-state-tree"
 /**
  * Model description here for TypeScript hints.
  */
-export const <%= props.pascalName %> = types
+export const <%= props.pascalName %>Model = types
   .model("<%= props.pascalName %>")
   .props({})
   .views(self => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -17,7 +17,7 @@ export const <%= props.pascalName %> = types
   *  .postProcessSnapshot(omit(["password", "socialSecurityNumber", "creditCardNumber"]))
   */
 
-type <%= props.pascalName %>Type = Instance<typeof <%= props.pascalName %>>
+type <%= props.pascalName %>Type = Instance<typeof <%= props.pascalName %>Model>
 export interface <%= props.pascalName %> extends <%= props.pascalName %>Type {}
-type <%= props.pascalName %>SnapshotType = SnapshotOut<typeof <%= props.pascalName %>>
+type <%= props.pascalName %>SnapshotType = SnapshotOut<typeof <%= props.pascalName %>Model>
 export interface <%= props.pascalName %>Snapshot extends <%= props.pascalName %>SnapshotType {}

--- a/templates/model.ejs
+++ b/templates/model.ejs
@@ -3,7 +3,7 @@ import { Instance, SnapshotOut, types } from "mobx-state-tree"
 /**
  * Model description here for TypeScript hints.
  */
-export const <%= props.pascalName %>Model = types
+export const <%= props.pascalName %> = types
   .model("<%= props.pascalName %>")
   .props({})
   .views(self => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -17,7 +17,7 @@ export const <%= props.pascalName %>Model = types
   *  .postProcessSnapshot(omit(["password", "socialSecurityNumber", "creditCardNumber"]))
   */
 
-type <%= props.pascalName %>Type = Instance<typeof <%= props.pascalName %>Model>
+type <%= props.pascalName %>Type = Instance<typeof <%= props.pascalName %>>
 export interface <%= props.pascalName %> extends <%= props.pascalName %>Type {}
-type <%= props.pascalName %>SnapshotType = SnapshotOut<typeof <%= props.pascalName %>Model>
+type <%= props.pascalName %>SnapshotType = SnapshotOut<typeof <%= props.pascalName %>>
 export interface <%= props.pascalName %>Snapshot extends <%= props.pascalName %>SnapshotType {}


### PR DESCRIPTION
fix model generation adding ModelModel to name
on the following :
```
export const TestModelModel = types
type ConversationModelType = Instance<typeof TestModelModel>
type ConversationModelSnapshotType = SnapshotOut<typeof TestModelModel>
```